### PR TITLE
[feature/loginService > develop][#3] Login-Service 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ out/
 .vscode/
 
 application-local.yml
+application-jwt.yml
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'c
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'com.auth0:java-jwt:3.19.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'c
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
@@ -2,19 +2,20 @@ package com.footprint.auth.filter;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.footprint.auth.jwt.JwtService;
 import com.footprint.member.domain.Member;
@@ -26,24 +27,26 @@ import lombok.RequiredArgsConstructor;
  * Created by ShinD on 2022/05/18.
  */
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter implements Filter {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {//TODO Filter 를 상속받으면 두번 작동함
 
 	private final JwtService jwtService;
 	private final MemberRepository memberRepository;
 
+	private final List<String> NO_CHECK_URL = Arrays.asList("/login", "/signUp");
+
 
 	@Override
-	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
 		/*
-		요청 정보로부터 인증을 시도함. 인증 시 SecurityContextHolder 에 인증정보 저장
+			요청 정보로부터 인증을 시도함. 인증 시 SecurityContextHolder 에 인증정보 저장
 		 */
 		executeAuthentication((HttpServletRequest)request);
 
-		chain.doFilter(request,response);//필수!
+		if(SecurityContextHolder.getContext().getAuthentication() == null) {
+			filterChain.doFilter(request, response);
+		}
 	}
-
-
 
 	private void executeAuthentication(HttpServletRequest request) {
 		jwtService.extractToken(request)
@@ -58,7 +61,6 @@ public class JwtAuthenticationFilter implements Filter {
 
 	private void saveSecurityContextHolder(Member member) {
 		SecurityContext context = SecurityContextHolder.createEmptyContext();
-
 		UserDetails userDetails = User.builder()
 			.username(member.getId().toString())//UserDetails 의 username 에 id 값을 넣어줌
 			.password(member.getPassword())//이거 안해주면 오류남!

--- a/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.footprint.auth.filter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.footprint.auth.jwt.JwtService;
+import com.footprint.auth.jwt.JwtToken;
+import com.footprint.member.domain.Member;
+import com.footprint.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Created by ShinD on 2022/05/18.
+ */
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements Filter {
+
+	private final JwtService jwtService;
+	private final MemberRepository memberRepository;
+
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+		/*
+		요청 정보로부터 인증을 시도함. 인증 시 SecurityContextHolder 에 인증정보 저장
+		 */
+		executeAuthentication((HttpServletRequest)request);
+
+		chain.doFilter(request,response);//필수!
+	}
+
+
+
+	private void executeAuthentication(HttpServletRequest request) {
+		jwtService.extractToken(request)
+			      .filter(jwtService::isValid)
+			      .map(JwtToken::new)
+			      .map(jwtService::extractMemberId)
+			      .flatMap(memberRepository::findById)
+			      .ifPresent(this::saveSecurityContextHolder);
+	}
+
+
+
+
+	private void saveSecurityContextHolder(Member member) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+		UserDetails userDetails = User.builder()
+			.username(member.getId().toString())//UserDetails 의 username 에 id 값을 넣어줌
+			.password(member.getPassword())//이거 안해주면 오류남!
+			.authorities(new ArrayList<>()).build();
+
+		context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null));
+		SecurityContextHolder.setContext(context);
+	}
+}

--- a/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
@@ -17,7 +17,6 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import com.footprint.auth.jwt.JwtService;
-import com.footprint.auth.jwt.JwtToken;
 import com.footprint.member.domain.Member;
 import com.footprint.member.repository.MemberRepository;
 

--- a/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
@@ -48,7 +48,6 @@ public class JwtAuthenticationFilter implements Filter {
 
 	private void executeAuthentication(HttpServletRequest request) {
 		jwtService.extractToken(request)
-			      .map(JwtToken::new)
 			      .filter(jwtService::isValid)
 			      .map(jwtService::extractMemberId)
 			      .flatMap(memberRepository::findById)

--- a/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
@@ -32,9 +32,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {//TODO Filter
 	private final JwtService jwtService;
 	private final MemberRepository memberRepository;
 
-	private final List<String> NO_CHECK_URL = Arrays.asList("/login", "/signUp");
-
-
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 

--- a/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/footprint/auth/filter/JwtAuthenticationFilter.java
@@ -48,8 +48,8 @@ public class JwtAuthenticationFilter implements Filter {
 
 	private void executeAuthentication(HttpServletRequest request) {
 		jwtService.extractToken(request)
-			      .filter(jwtService::isValid)
 			      .map(JwtToken::new)
+			      .filter(jwtService::isValid)
 			      .map(jwtService::extractMemberId)
 			      .flatMap(memberRepository::findById)
 			      .ifPresent(this::saveSecurityContextHolder);

--- a/src/main/java/com/footprint/auth/filter/RestfulLoginFilter.java
+++ b/src/main/java/com/footprint/auth/filter/RestfulLoginFilter.java
@@ -1,0 +1,94 @@
+package com.footprint.auth.filter;
+
+import static java.util.Objects.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.util.StreamUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Created by ShinD on 2022/05/17.
+ */
+public class RestfulLoginFilter extends UsernamePasswordAuthenticationFilter {
+
+
+	private final ObjectMapper objectMapper;
+
+
+	public RestfulLoginFilter(AuthenticationManager authenticationManager, ObjectMapper objectMapper) {
+		super(authenticationManager);
+		this.objectMapper = objectMapper;
+	}
+
+
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+		/*
+			POST 메서드로 보낸 요청만 처리
+		 */
+		if (!request.getMethod().equals("POST")) {
+			throw new AuthenticationServiceException("Authentication method not supported: " + request.getMethod());
+		}
+
+		/*
+			Username 과 Password 가 들어있는 HashMap 을 반환
+		 */
+		HashMap<String, String> authMap = getAuthInfoHashMap(getMessageBody(request));
+
+		UsernamePasswordAuthenticationToken authRequest = makeAuthenticationToken(authMap);
+		setDetails(request, authRequest);
+
+		return this.getAuthenticationManager().authenticate(authRequest);
+	}
+
+
+
+
+	private UsernamePasswordAuthenticationToken makeAuthenticationToken(HashMap<String, String> authMap) {
+		String username = authMap.get(SPRING_SECURITY_FORM_USERNAME_KEY);
+		String password = authMap.get(SPRING_SECURITY_FORM_PASSWORD_KEY);
+		return new UsernamePasswordAuthenticationToken(username, password);
+	}
+
+
+
+	private HashMap<String, String> getAuthInfoHashMap(String messageBody) {
+		try {
+
+			HashMap<String, String> authInfo = objectMapper.readValue(messageBody, new TypeReference<HashMap<String, String>>() {});
+
+			authInfo.put(SPRING_SECURITY_FORM_USERNAME_KEY, requireNonNull(authInfo.get(SPRING_SECURITY_FORM_USERNAME_KEY)).trim());
+			authInfo.put(SPRING_SECURITY_FORM_PASSWORD_KEY, requireNonNull(authInfo.get(SPRING_SECURITY_FORM_PASSWORD_KEY)).trim());
+
+			return authInfo;
+		} catch (JsonProcessingException | NullPointerException e) {
+			throw new AuthenticationServiceException(e.getMessage());
+		}
+	}
+
+
+	private String getMessageBody(HttpServletRequest request) throws AuthenticationException {
+		try {
+			return StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new AuthenticationServiceException(e.getMessage());
+		}
+	}
+
+}

--- a/src/main/java/com/footprint/auth/handler/RestfulAuthenticationSuccessHandler.java
+++ b/src/main/java/com/footprint/auth/handler/RestfulAuthenticationSuccessHandler.java
@@ -1,0 +1,27 @@
+package com.footprint.auth.handler;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import com.footprint.auth.jwt.JwtService;
+
+/**
+ * Created by ShinD on 2022/05/18.
+ */
+public record RestfulAuthenticationSuccessHandler(JwtService jwtService) implements AuthenticationSuccessHandler {
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+		jwtService
+			.sendToken(response, jwtService.createAccessToken(
+				Long.parseLong(((User)authentication.getPrincipal()).getUsername())));//getUsername 에는 회원의 PK, 즉 id 가 들어있음
+
+	}
+}

--- a/src/main/java/com/footprint/auth/jwt/JwtService.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtService.java
@@ -1,0 +1,21 @@
+package com.footprint.auth.jwt;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Created by ShinD on 2022/05/18.
+ */
+public interface JwtService {
+	JwtToken createAccessToken(Long memberId);
+
+	Long extractMemberId(JwtToken token);
+
+	void sendToken(HttpServletResponse response, JwtToken token);
+
+	Optional<String> extractToken(HttpServletRequest request);
+
+	boolean isValid(String jwt);
+}

--- a/src/main/java/com/footprint/auth/jwt/JwtService.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtService.java
@@ -17,5 +17,5 @@ public interface JwtService {
 
 	Optional<String> extractToken(HttpServletRequest request);
 
-	boolean isValid(String jwt);
+	boolean isValid(JwtToken token);
 }

--- a/src/main/java/com/footprint/auth/jwt/JwtService.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtService.java
@@ -9,7 +9,7 @@ import javax.servlet.http.HttpServletResponse;
  * Created by ShinD on 2022/05/18.
  */
 public interface JwtService {
-	JwtToken createAccessToken(Long memberId);
+	JwtToken createAccessToken(Long memberId);//TODO memberId 로만 구성하면 보안상 문제. 이후 배포할 때 바꾸어야 함
 
 	Long extractMemberId(JwtToken token);
 

--- a/src/main/java/com/footprint/auth/jwt/JwtService.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtService.java
@@ -15,7 +15,7 @@ public interface JwtService {
 
 	void sendToken(HttpServletResponse response, JwtToken token);
 
-	Optional<String> extractToken(HttpServletRequest request);
+	Optional<JwtToken> extractToken(HttpServletRequest request);
 
 	boolean isValid(JwtToken token);
 }

--- a/src/main/java/com/footprint/auth/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtServiceImpl.java
@@ -86,12 +86,7 @@ public class JwtServiceImpl implements JwtService{
 	 * JWT 가 유효한지 검사
 	 */
 	@Override
-	public boolean isValid(String jwt) {
-		try {
-			JWT.require(algorithm).build().verify(jwt);
-			return true;
-		}catch (Exception e){
-			return false;
-		}
+	public boolean isValid(JwtToken token) {
+		return token.isValid(algorithm);
 	}
 }

--- a/src/main/java/com/footprint/auth/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtServiceImpl.java
@@ -7,7 +7,6 @@ import static java.util.Optional.*;
 import static java.util.concurrent.TimeUnit.*;
 
 import java.util.Date;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -78,8 +77,8 @@ public class JwtServiceImpl implements JwtService{
 	 * 요청으로부터 포함된 JWT 가 있다면 추출하여 반환
 	 */
 	@Override
-	public Optional<String> extractToken(HttpServletRequest request) {
-		return ofNullable(request.getHeader(BEARER_HEADER));
+	public Optional<JwtToken> extractToken(HttpServletRequest request) {
+		return ofNullable(JwtToken.from(request.getHeader(BEARER_HEADER)));
 	}
 
 	/**

--- a/src/main/java/com/footprint/auth/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtServiceImpl.java
@@ -1,0 +1,97 @@
+package com.footprint.auth.jwt;
+
+import static com.auth0.jwt.algorithms.Algorithm.*;
+import static com.footprint.auth.jwt.JwtToken.*;
+import static java.lang.System.*;
+import static java.util.Optional.*;
+import static java.util.concurrent.TimeUnit.*;
+
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
+/**
+ * Created by ShinD on 2022/05/18.
+ */
+
+@Component
+public class JwtServiceImpl implements JwtService{
+
+	public static final String BEARER_HEADER = "Bearer";
+
+	@Value("${jwt.secret}")
+	private String secretKey;
+
+	@Value("${jwt.expirationDay}")
+	private long accessTokenValidity;//AccessToken 의 유효기간
+
+
+	private Algorithm algorithm;
+
+
+
+
+
+	@PostConstruct
+	private void setAlgorithm(){
+		algorithm = HMAC512(secretKey);
+	}
+
+
+	@Override
+	public JwtToken createAccessToken(Long id) {
+		return JwtToken.from(JWT.create()
+								.withSubject(ACCESS_TOKEN_SUBJECT) //토큰의 제목
+								.withClaim(MEMBER_ID_CLAIM, id)    //토큰의 클레임(정보들)
+								.withExpiresAt(new Date(currentTimeMillis() + MILLISECONDS.convert(accessTokenValidity, TimeUnit.DAYS)))
+								.sign(algorithm));
+	}
+
+	/**
+	 * Jwt 에서 회원의 memberId를 추출함
+	 */
+	@Override
+	public Long extractMemberId(JwtToken token) {
+		return JWT.require(algorithm).build().verify(token.content()).getClaim(MEMBER_ID_CLAIM).asLong();
+	}
+
+	/**
+	 * 응답의 Header 에 jwt 설정
+	 */
+	@Override
+	public void sendToken(HttpServletResponse response, JwtToken token) {
+		response.setHeader(BEARER_HEADER, token.content());
+	}
+
+	/**
+	 * 요청으로부터 포함된 JWT 가 있다면 추출하여 반환
+	 */
+	@Override
+	public Optional<String> extractToken(HttpServletRequest request) {
+		return ofNullable(request.getHeader(BEARER_HEADER));
+	}
+
+	/**
+	 * JWT 가 유효한지 검사
+	 */
+	@Override
+	public boolean isValid(String jwt) {
+		try {
+			JWT.require(algorithm).build().verify(jwt);
+			return true;
+		}catch (Exception e){
+			return false;
+		}
+	}
+}

--- a/src/main/java/com/footprint/auth/jwt/JwtToken.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtToken.java
@@ -1,5 +1,8 @@
 package com.footprint.auth.jwt;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
 /**
  * Created by ShinD on 2022/05/18.
  */
@@ -12,4 +15,12 @@ public record JwtToken(String content) {
 		return new JwtToken(content);
 	}
 
+	public boolean isValid(Algorithm algorithm) {
+		try {
+			JWT.require(algorithm).build().verify(this.content);
+			return true;
+		}catch (Exception e){
+			return false;
+		}
+	}
 }

--- a/src/main/java/com/footprint/auth/jwt/JwtToken.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtToken.java
@@ -12,7 +12,7 @@ public record JwtToken(String content) {
 	public static final String MEMBER_ID_CLAIM = "memberId";
 
 	public static JwtToken from(String content) {
-		return new JwtToken(content);
+		return (content == null) ? null : new JwtToken(content);
 	}
 
 	public boolean isValid(Algorithm algorithm) {

--- a/src/main/java/com/footprint/auth/jwt/JwtToken.java
+++ b/src/main/java/com/footprint/auth/jwt/JwtToken.java
@@ -1,0 +1,15 @@
+package com.footprint.auth.jwt;
+
+/**
+ * Created by ShinD on 2022/05/18.
+ */
+public record JwtToken(String content) {
+
+	public static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+	public static final String MEMBER_ID_CLAIM = "memberId";
+
+	public static JwtToken from(String content) {
+		return new JwtToken(content);
+	}
+
+}

--- a/src/main/java/com/footprint/comment/domain/Comment.java
+++ b/src/main/java/com/footprint/comment/domain/Comment.java
@@ -3,10 +3,6 @@ package com.footprint.comment.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -20,6 +16,10 @@ import javax.persistence.OneToMany;
 import com.footprint.common.BaseTimeEntity;
 import com.footprint.maintravel.domain.MainTravel;
 import com.footprint.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/footprint/common/exception/BaseException.java
+++ b/src/main/java/com/footprint/common/exception/BaseException.java
@@ -1,5 +1,5 @@
 package com.footprint.common.exception;
 
-public abstract class BaseException {
+public abstract class BaseException extends RuntimeException{
 	public abstract BaseExceptionType getExceptionType();
 }

--- a/src/main/java/com/footprint/config/SecurityConfig.java
+++ b/src/main/java/com/footprint/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.footprint.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+/**
+ * Created by ShinD on 2022/05/14.
+ */
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http
+			.formLogin().disable()
+			.httpBasic().disable() // Header 에 username, password 를 실어 보내 인증하는 방식 비활성화
+			.csrf().disable()
+			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+			.and()
+			.authorizeRequests()
+			.antMatchers("/login", "/signUp").permitAll()
+			.anyRequest().authenticated();
+	}
+
+
+
+
+}

--- a/src/main/java/com/footprint/config/SecurityConfig.java
+++ b/src/main/java/com/footprint/config/SecurityConfig.java
@@ -1,15 +1,39 @@
 package com.footprint.config;
 
+import static org.springframework.security.config.http.SessionCreationPolicy.*;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.footprint.auth.filter.JwtAuthenticationFilter;
+import com.footprint.auth.filter.RestfulLoginFilter;
+import com.footprint.auth.handler.RestfulAuthenticationSuccessHandler;
+import com.footprint.auth.jwt.JwtService;
+import com.footprint.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
 
 /**
  * Created by ShinD on 2022/05/14.
  */
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+
+	private final ObjectMapper objectMapper;
+	private final JwtService jwtService;
+	private final MemberRepository memberRepository;
+
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
@@ -17,12 +41,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			.formLogin().disable()
 			.httpBasic().disable() // Header 에 username, password 를 실어 보내 인증하는 방식 비활성화
 			.csrf().disable()
-			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.sessionManagement().sessionCreationPolicy(STATELESS)
 
 			.and()
 			.authorizeRequests()
-			.antMatchers("/login", "/signUp").permitAll()
+			.antMatchers("/login", "/signUp").permitAll()//TODO 따로 빼서 관리하는 것이 나을지, 아니면 이대로 사용할지
 			.anyRequest().authenticated();
+
+		http.addFilterAfter(restfulLoginFilter(), LogoutFilter.class);
+		http.addFilterBefore(jwtAuthenticationFilter(), RestfulLoginFilter.class);
 	}
 
 
@@ -32,4 +59,22 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		return PasswordEncoderFactories.createDelegatingPasswordEncoder();//bcrypt 사용
 	}
 
+
+	@Bean
+	public UsernamePasswordAuthenticationFilter restfulLoginFilter() throws Exception {
+		RestfulLoginFilter restfulLoginFilter = new RestfulLoginFilter(authenticationManager(), objectMapper);
+
+		restfulLoginFilter.setAuthenticationSuccessHandler(restfulAuthenticationSuccessHandler());
+		return restfulLoginFilter;
+	}
+
+	@Bean
+	public AuthenticationSuccessHandler restfulAuthenticationSuccessHandler() {
+		return new RestfulAuthenticationSuccessHandler(jwtService);
+	}
+
+	@Bean
+	public JwtAuthenticationFilter jwtAuthenticationFilter() {
+		return new JwtAuthenticationFilter(jwtService, memberRepository);
+	}
 }

--- a/src/main/java/com/footprint/config/SecurityConfig.java
+++ b/src/main/java/com/footprint/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;

--- a/src/main/java/com/footprint/config/SecurityConfig.java
+++ b/src/main/java/com/footprint/config/SecurityConfig.java
@@ -27,5 +27,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 
 
+	@Bean
+	public PasswordEncoder passwordEncoder(){
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();//bcrypt 사용
+	}
 
 }

--- a/src/main/java/com/footprint/detailedtravel/domain/DetailTravel.java
+++ b/src/main/java/com/footprint/detailedtravel/domain/DetailTravel.java
@@ -4,10 +4,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -15,17 +11,20 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.persistence.Id;
 
-import com.footprint.comment.domain.Comment;
 import com.footprint.image.domain.Image;
 import com.footprint.maintravel.domain.MainTravel;
 import com.footprint.price.domain.Price;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Table(name = "detail_travel")

--- a/src/main/java/com/footprint/follow/domain/Follow.java
+++ b/src/main/java/com/footprint/follow/domain/Follow.java
@@ -1,19 +1,20 @@
 package com.footprint.follow.domain;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.Id;
 
 import com.footprint.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Table(name = "follow")

--- a/src/main/java/com/footprint/heart/domain/Heart.java
+++ b/src/main/java/com/footprint/heart/domain/Heart.java
@@ -1,20 +1,21 @@
 package com.footprint.heart.domain;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.Id;
 
 import com.footprint.maintravel.domain.MainTravel;
 import com.footprint.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Table(name = "heart")

--- a/src/main/java/com/footprint/image/domain/Image.java
+++ b/src/main/java/com/footprint/image/domain/Image.java
@@ -1,20 +1,20 @@
 package com.footprint.image.domain;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.Id;
 
 import com.footprint.detailedtravel.domain.DetailTravel;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Table(name = "image")

--- a/src/main/java/com/footprint/maintravel/domain/MainTravel.java
+++ b/src/main/java/com/footprint/maintravel/domain/MainTravel.java
@@ -4,22 +4,18 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import javax.persistence.Id;
 
 import com.footprint.comment.domain.Comment;
 import com.footprint.detailedtravel.domain.DetailTravel;
@@ -27,6 +23,10 @@ import com.footprint.heart.domain.Heart;
 import com.footprint.image.domain.Image;
 import com.footprint.member.domain.Member;
 import com.footprint.scrap.domain.Scrap;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Table(name = "main_travel")

--- a/src/main/java/com/footprint/member/controller/MemberController.java
+++ b/src/main/java/com/footprint/member/controller/MemberController.java
@@ -1,0 +1,32 @@
+package com.footprint.member.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.footprint.member.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Created by ShinD on 2022/05/18.
+ */
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	/**
+	 * 회원가입
+	 */
+	@PostMapping("/signUp")
+	public ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest){
+		memberService.create(signUpRequest.toServiceDto());
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+
+}

--- a/src/main/java/com/footprint/member/controller/SignUpRequest.java
+++ b/src/main/java/com/footprint/member/controller/SignUpRequest.java
@@ -5,9 +5,9 @@ import com.footprint.member.service.dto.CreateMemberDto;
 /**
  * Created by ShinD on 2022/05/18.
  */
-public record SignUpRequest (String username, String password, String nickName) {
+public record SignUpRequest (String username, String password, String nickname) {
 
 	public CreateMemberDto toServiceDto() {
-		return CreateMemberDto.builder().username(username).password(password).nickName(nickName).build();
+		return CreateMemberDto.builder().username(username).password(password).nickname(nickname).build();
 	}
 }

--- a/src/main/java/com/footprint/member/controller/SignUpRequest.java
+++ b/src/main/java/com/footprint/member/controller/SignUpRequest.java
@@ -1,0 +1,13 @@
+package com.footprint.member.controller;
+
+import com.footprint.member.service.dto.CreateMemberDto;
+
+/**
+ * Created by ShinD on 2022/05/18.
+ */
+public record SignUpRequest (String username, String password, String nickName) {
+
+	public CreateMemberDto toServiceDto() {
+		return CreateMemberDto.builder().username(username).password(password).nickName(nickName).build();
+	}
+}

--- a/src/main/java/com/footprint/member/domain/Member.java
+++ b/src/main/java/com/footprint/member/domain/Member.java
@@ -1,11 +1,11 @@
 package com.footprint.member.domain;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.persistence.Column;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/footprint/member/exception/MemberException.java
+++ b/src/main/java/com/footprint/member/exception/MemberException.java
@@ -1,0 +1,4 @@
+package com.footprint.member.exception;/**
+ * Created by ShinD on 2022/05/14.
+ */public class MemberException {
+}

--- a/src/main/java/com/footprint/member/exception/MemberException.java
+++ b/src/main/java/com/footprint/member/exception/MemberException.java
@@ -1,4 +1,21 @@
-package com.footprint.member.exception;/**
+package com.footprint.member.exception;
+
+import com.footprint.common.exception.BaseException;
+import com.footprint.common.exception.BaseExceptionType;
+
+/**
  * Created by ShinD on 2022/05/14.
- */public class MemberException {
+ */
+public class MemberException extends BaseException {
+
+	private final MemberExceptionType memberExceptionType;
+
+	public MemberException(MemberExceptionType memberExceptionType) {
+		this.memberExceptionType = memberExceptionType;
+	}
+
+	@Override
+	public BaseExceptionType getExceptionType() {
+		return this.memberExceptionType;
+	}
 }

--- a/src/main/java/com/footprint/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/footprint/member/exception/MemberExceptionType.java
@@ -1,4 +1,41 @@
-package com.footprint.member.exception;/**
+package com.footprint.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.footprint.common.exception.BaseExceptionType;
+
+/**
  * Created by ShinD on 2022/05/14.
- */public class MemberExceptionType {
+ */
+public enum MemberExceptionType implements BaseExceptionType {
+
+	NOT_FOUND(100, HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다."),
+	DUPLICATE_USERNAME(101, HttpStatus.CONFLICT,"이미 존재하는 아이디입니다.");
+
+
+
+	private final int errorCode;
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+
+	MemberExceptionType(int errorCode, HttpStatus httpStatus, String errorMessage) {
+		this.errorCode = errorCode;
+		this.httpStatus = httpStatus;
+		this.errorMessage = errorMessage;
+	}
+
+	@Override
+	public int getErrorCode() {
+		return this.errorCode;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return this.httpStatus;
+	}
+
+	@Override
+	public String getErrorMessage() {
+		return this.errorMessage;
+	}
 }

--- a/src/main/java/com/footprint/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/footprint/member/exception/MemberExceptionType.java
@@ -1,0 +1,4 @@
+package com.footprint.member.exception;/**
+ * Created by ShinD on 2022/05/14.
+ */public class MemberExceptionType {
+}

--- a/src/main/java/com/footprint/member/repository/MemberRepository.java
+++ b/src/main/java/com/footprint/member/repository/MemberRepository.java
@@ -1,0 +1,4 @@
+package com.footprint.member.repository;/**
+ * Created by ShinD on 2022/05/14.
+ */public class MemberRepository {
+}

--- a/src/main/java/com/footprint/member/repository/MemberRepository.java
+++ b/src/main/java/com/footprint/member/repository/MemberRepository.java
@@ -1,4 +1,15 @@
-package com.footprint.member.repository;/**
+package com.footprint.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.footprint.member.domain.Member;
+
+/**
  * Created by ShinD on 2022/05/14.
- */public class MemberRepository {
+ */
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/com/footprint/member/service/MemberService.java
+++ b/src/main/java/com/footprint/member/service/MemberService.java
@@ -1,0 +1,4 @@
+package com.footprint.member.service;/**
+ * Created by ShinD on 2022/05/14.
+ */public interface MemberService {
+}

--- a/src/main/java/com/footprint/member/service/MemberService.java
+++ b/src/main/java/com/footprint/member/service/MemberService.java
@@ -1,4 +1,14 @@
-package com.footprint.member.service;/**
+package com.footprint.member.service;
+
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import com.footprint.member.service.dto.CreateMemberDto;
+
+/**
  * Created by ShinD on 2022/05/14.
- */public interface MemberService {
+ */
+public interface MemberService extends UserDetailsService {
+
+	void create(CreateMemberDto createMemberDto);
+
 }

--- a/src/main/java/com/footprint/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/footprint/member/service/MemberServiceImpl.java
@@ -1,4 +1,74 @@
-package com.footprint.member.service;/**
+package com.footprint.member.service;
+
+import static com.footprint.member.exception.MemberExceptionType.*;
+
+import java.util.ArrayList;
+
+import javax.transaction.Transactional;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.footprint.member.domain.Member;
+import com.footprint.member.exception.MemberException;
+import com.footprint.member.repository.MemberRepository;
+import com.footprint.member.service.dto.CreateMemberDto;
+
+import lombok.RequiredArgsConstructor;
+
+/**
  * Created by ShinD on 2022/05/14.
- */public class MemberServiceImpl {
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService{
+
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	/**
+	 * 회원가입
+	 */
+	@Override
+	public void create(CreateMemberDto createMemberDto) {
+
+		//TODO 비밀번호를 암호화 하는 책임을 Member 에 둘지, encodePassword 에 둘지 고민
+		createMemberDto.encodePassword(passwordEncoder);
+
+		Member member = createMemberDto.toEntity();
+
+		checkDuplicateUsername(member.getUsername());
+
+		memberRepository.save(member);
+	}
+
+
+
+	/**
+	 * 아이디 중복여부 체크
+	 * 중복되었을 경우 MemberException 발생
+	 */
+	private void checkDuplicateUsername(String username) {
+		memberRepository.findByUsername(username).ifPresent((member)-> {
+			throw new MemberException(DUPLICATE_USERNAME);
+		} );
+	}
+
+
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		Member member = memberRepository.findByUsername(username)
+										.orElseThrow(() -> new UsernameNotFoundException("회원을 찾을 수 없습니다."));
+
+		return User.builder()
+			.username(username)
+			.password(member.getPassword())
+			.authorities(new ArrayList<>()) //TODO 어드민 등의 관리자 계정이 따로 필요하다면 수정
+			.build();
+	}
 }

--- a/src/main/java/com/footprint/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/footprint/member/service/MemberServiceImpl.java
@@ -66,7 +66,7 @@ public class MemberServiceImpl implements MemberService{
 										.orElseThrow(() -> new UsernameNotFoundException("회원을 찾을 수 없습니다."));
 
 		return User.builder()
-			.username(username)
+			.username(member.getId().toString())
 			.password(member.getPassword())
 			.authorities(new ArrayList<>()) //TODO 어드민 등의 관리자 계정이 따로 필요하다면 수정
 			.build();

--- a/src/main/java/com/footprint/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/footprint/member/service/MemberServiceImpl.java
@@ -1,0 +1,4 @@
+package com.footprint.member.service;/**
+ * Created by ShinD on 2022/05/14.
+ */public class MemberServiceImpl {
+}

--- a/src/main/java/com/footprint/member/service/dto/CreateMemberDto.java
+++ b/src/main/java/com/footprint/member/service/dto/CreateMemberDto.java
@@ -1,0 +1,4 @@
+package com.footprint.member.service.dto;/**
+ * Created by ShinD on 2022/05/14.
+ */public class CreateMemberDto {
+}

--- a/src/main/java/com/footprint/member/service/dto/CreateMemberDto.java
+++ b/src/main/java/com/footprint/member/service/dto/CreateMemberDto.java
@@ -1,4 +1,34 @@
-package com.footprint.member.service.dto;/**
+package com.footprint.member.service.dto;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.footprint.member.domain.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
  * Created by ShinD on 2022/05/14.
- */public class CreateMemberDto {
+ */
+@Getter
+public class CreateMemberDto {
+
+	private String username;
+	private String password;
+	private String nickName;
+
+	@Builder
+	public CreateMemberDto(String username, String password, String nickName) {
+		this.username = username;
+		this.password = password;
+		this.nickName = nickName;
+	}
+
+	public void encodePassword(PasswordEncoder passwordEncoder) {
+		this.password = passwordEncoder.encode(password);
+	}
+
+	public Member toEntity() {
+		return Member.builder().username(username).password(password).nickname(nickName).build();
+	}
 }

--- a/src/main/java/com/footprint/member/service/dto/CreateMemberDto.java
+++ b/src/main/java/com/footprint/member/service/dto/CreateMemberDto.java
@@ -15,13 +15,13 @@ public class CreateMemberDto {
 
 	private String username;
 	private String password;
-	private String nickName;
+	private String nickname;
 
 	@Builder
-	public CreateMemberDto(String username, String password, String nickName) {
+	public CreateMemberDto(String username, String password, String nickname) {
 		this.username = username;
 		this.password = password;
-		this.nickName = nickName;
+		this.nickname = nickname;
 	}
 
 	public void encodePassword(PasswordEncoder passwordEncoder) {
@@ -29,6 +29,6 @@ public class CreateMemberDto {
 	}
 
 	public Member toEntity() {
-		return Member.builder().username(username).password(password).nickname(nickName).build();
+		return Member.builder().username(username).password(password).nickname(nickname).build();
 	}
 }

--- a/src/main/java/com/footprint/price/domain/Price.java
+++ b/src/main/java/com/footprint/price/domain/Price.java
@@ -1,19 +1,20 @@
 package com.footprint.price.domain;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.Id;
 
 import com.footprint.detailedtravel.domain.DetailTravel;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Table(name = "price")

--- a/src/main/java/com/footprint/scrap/domain/Scrap.java
+++ b/src/main/java/com/footprint/scrap/domain/Scrap.java
@@ -1,23 +1,23 @@
 package com.footprint.scrap.domain;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.Id;
 
 import com.footprint.common.BaseTimeEntity;
 import com.footprint.maintravel.domain.MainTravel;
 import com.footprint.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Table(name = "scrap")

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/footprint
+    username: user
+    password: mypass
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      show_sql: true
+      format_sql: true
+    database-platform: org.hibernate.dialect.MySQL5Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,4 @@
 spring:
   profiles:
-    include: local
+    include: local, jwt
+    active: local, jwt

--- a/src/test/java/com/footprint/FootprintApplicationTests.java
+++ b/src/test/java/com/footprint/FootprintApplicationTests.java
@@ -8,6 +8,7 @@ class FootprintApplicationTests {
 
 	@Test
 	void contextLoads() {
+
 	}
 
 }

--- a/src/test/java/com/footprint/auth/AuthTest.java
+++ b/src/test/java/com/footprint/auth/AuthTest.java
@@ -1,0 +1,169 @@
+package com.footprint.auth;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.footprint.auth.jwt.JwtService;
+import com.footprint.auth.jwt.JwtServiceImpl;
+import com.footprint.auth.jwt.JwtToken;
+import com.footprint.member.domain.Member;
+import com.footprint.member.service.MemberService;
+import com.footprint.member.service.dto.CreateMemberDto;
+/**
+ * Created by ShinD on 2022/05/19.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc //https://we1cometomeanings.tistory.com/65
+@Transactional
+public class AuthTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	MemberService memberService;
+
+	@Autowired
+	JwtService jwtService;
+
+	@Autowired
+	EntityManager em;
+
+	ObjectMapper objectMapper = new ObjectMapper();
+	static final String LOGIN_URL = "/login";
+
+
+
+	private Map<String, String> signUp(){
+		String username = "username";
+		String password = "password";
+		String nickName = "nickName";
+
+		CreateMemberDto createMemberDto = new CreateMemberDto(username, password, nickName);
+
+		memberService.create(createMemberDto);
+
+		Map<String, String> authMap = new HashMap<>();
+		authMap.put("username", username);
+		authMap.put("password", password);
+		return authMap;
+	}
+
+
+
+	@Test
+	@DisplayName("로그인 성공")
+	public void loginTest() throws Exception {
+	    //given
+		Map<String, String> authMap = signUp();
+		objectMapper.writeValueAsString(authMap);
+
+		//when
+		MvcResult result = mockMvc.perform(
+											post(LOGIN_URL)
+											.contentType(MediaType.APPLICATION_JSON)
+											.content(objectMapper.writeValueAsString(authMap)))
+										.andExpect(status().isOk())
+										.andReturn();
+
+	    //then
+		Assertions.assertThat(result.getResponse().getHeader(JwtServiceImpl.BEARER_HEADER)).isNotNull();
+		Assertions.assertThat(result.getResponse().getHeader(JwtServiceImpl.BEARER_HEADER).split("\\.")).hasSize(3);
+	}
+
+
+	@Test
+	@DisplayName("로그인 실패 - 아이디 틀림")
+	public void failLoginByWrongUsername() throws Exception {
+		//given
+		Map<String, String> authMap = signUp();
+		authMap.put("username", "1");
+		objectMapper.writeValueAsString(authMap);
+
+		//when
+		MvcResult result = mockMvc.perform(
+											post(LOGIN_URL)
+											.contentType(MediaType.APPLICATION_JSON)
+											.content(objectMapper.writeValueAsString(authMap)))
+									.andExpect(status().isUnauthorized())
+									.andReturn();
+
+		//then
+		Assertions.assertThat(result.getResponse().getHeader(JwtServiceImpl.BEARER_HEADER)).isNull();
+	}
+
+	@Test
+	@DisplayName("로그인 실패 - 비밀번호 틀림")
+	public void failLoginByWrongPassword() throws Exception {
+		//given
+		Map<String, String> authMap = signUp();
+		authMap.put("password", "1");
+		objectMapper.writeValueAsString(authMap);
+
+		//when
+		MvcResult result = mockMvc.perform(
+											post(LOGIN_URL)
+											.contentType(MediaType.APPLICATION_JSON)
+											.content(objectMapper.writeValueAsString(authMap)))
+									.andExpect(status().isUnauthorized())
+									.andReturn();
+
+		//then
+		Assertions.assertThat(result.getResponse().getHeader(JwtServiceImpl.BEARER_HEADER)).isNull();
+	}
+
+
+	@Test
+	@DisplayName("AccessToken으로 접근 - 성공")
+	public void successAccessByAccessToken() throws Exception {
+		//given
+		signUp();
+
+		JwtToken accessToken = jwtService.createAccessToken(
+			em.createQuery("select m from Member m", Member.class).getSingleResult().getId());
+
+
+		//when, then
+		mockMvc.perform(
+				get("/any")
+					.header(JwtServiceImpl.BEARER_HEADER, accessToken.content())
+			)
+			.andExpect(status().is2xxSuccessful());
+	}
+
+	@Test
+	@DisplayName("AccessToken으로 접근 - 실패 (원인 : 유효하지 않은 AccessToken)")
+	public void failAccessByAccessToken() throws Exception {
+		//given
+		signUp();
+
+		JwtToken accessToken = jwtService.createAccessToken(
+			em.createQuery("select m from Member m", Member.class).getSingleResult().getId());
+
+
+		mockMvc.perform(
+				get("/any")
+					.header(JwtServiceImpl.BEARER_HEADER, accessToken.content()+"123")
+			)
+			.andExpect(status().isForbidden());
+	}
+
+
+}

--- a/src/test/java/com/footprint/auth/AuthTest.java
+++ b/src/test/java/com/footprint/auth/AuthTest.java
@@ -35,19 +35,24 @@ import com.footprint.member.service.dto.CreateMemberDto;
 public class AuthTest {
 
 	@Autowired
-	MockMvc mockMvc;
+	private MockMvc mockMvc;
 
 	@Autowired
-	MemberService memberService;
+	private MemberService memberService;
 
 	@Autowired
-	JwtService jwtService;
+	private JwtService jwtService;
 
 	@Autowired
-	EntityManager em;
+	private EntityManager em;
 
-	ObjectMapper objectMapper = new ObjectMapper();
-	static final String LOGIN_URL = "/login";
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	private static final String LOGIN_URL = "/login";
+
+	private static final String WRONG_USERNAME = "wrong-username";
+	private static final String WRONG_PASSWORD = "wrong-password";
+	private static final String INVALID_TOKEN = "invalid-token";
 
 
 
@@ -94,7 +99,7 @@ public class AuthTest {
 	public void failLoginByWrongUsername() throws Exception {
 		//given
 		Map<String, String> authMap = signUp();
-		authMap.put("username", "1");
+		authMap.put("username", WRONG_USERNAME);
 		objectMapper.writeValueAsString(authMap);
 
 		//when
@@ -114,7 +119,7 @@ public class AuthTest {
 	public void failLoginByWrongPassword() throws Exception {
 		//given
 		Map<String, String> authMap = signUp();
-		authMap.put("password", "1");
+		authMap.put("password", WRONG_PASSWORD);
 		objectMapper.writeValueAsString(authMap);
 
 		//when
@@ -160,7 +165,7 @@ public class AuthTest {
 
 		mockMvc.perform(
 				get("/any")
-					.header(JwtServiceImpl.BEARER_HEADER, accessToken.content()+"123")
+					.header(JwtServiceImpl.BEARER_HEADER, INVALID_TOKEN)
 			)
 			.andExpect(status().isForbidden());
 	}

--- a/src/test/java/com/footprint/auth/jwt/JwtServiceTest.java
+++ b/src/test/java/com/footprint/auth/jwt/JwtServiceTest.java
@@ -1,0 +1,167 @@
+package com.footprint.auth.jwt;
+
+import static com.auth0.jwt.algorithms.Algorithm.*;
+import static com.footprint.auth.jwt.JwtServiceImpl.*;
+import static java.lang.System.*;
+import static java.util.concurrent.TimeUnit.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+/**
+ * Created by ShinD on 2022/05/18.
+ */
+@SpringBootTest
+class JwtServiceTest {
+
+	@Autowired
+	private JwtService jwtService;
+
+	@Value("${jwt.secret}")
+	private String secret;
+
+	@Value("${jwt.expirationDay}")
+	private long accessTokenValidity;//AccessToken 의 유효기간
+
+
+
+
+	private DecodedJWT getVerify(String token) {
+		return JWT.require(HMAC512(secret)).build().verify(token);
+	}
+
+	private HttpServletRequest setRequest(JwtToken accessToken) {
+		MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+		httpServletRequest.addHeader(BEARER_HEADER, accessToken.content());
+
+		return httpServletRequest;
+	}
+
+
+	@Test
+	@DisplayName("AccessToken 발급 테스트 - 성공")
+	public void successCreateAccessToken() throws Exception {
+	    //given
+		Long memberId = 1L;
+
+		//when
+		JwtToken accessToken = jwtService.createAccessToken(memberId);
+
+	    //then
+		DecodedJWT verify = getVerify(accessToken.content());
+		assertThat(verify.getClaim(JwtToken.MEMBER_ID_CLAIM).asLong()).isEqualTo(memberId);
+		assertThat(
+				verify.getExpiresAt().before(new Date(
+					currentTimeMillis() + MILLISECONDS.convert(accessTokenValidity, TimeUnit.DAYS))
+				)).isTrue();
+		assertThat(
+			verify.getExpiresAt().after(new Date(
+				currentTimeMillis() + MILLISECONDS.convert(accessTokenValidity, TimeUnit.DAYS) - + MILLISECONDS.convert(1, HOURS))
+			)).isTrue();
+	}
+
+
+	@Test
+	@DisplayName("AccessToken 에서 memberId 추출 - 성공")
+	public void successExtractMemberId() throws Exception {
+		//given
+		Long memberId = 1L;
+		JwtToken accessToken = jwtService.createAccessToken(memberId);
+
+		//when
+		Long extractMemberId = jwtService.extractMemberId(accessToken);
+
+		//then
+		assertThat(extractMemberId).isEqualTo(memberId);
+	}
+
+
+
+
+
+	@Test
+	@DisplayName("토큰 유효성 검사 - 성공")
+	public void successTokenValidity() throws Exception {
+		//given
+		Long memberId = 1L;
+		JwtToken accessToken = jwtService.createAccessToken(memberId);
+
+		//when, then
+		assertThat(jwtService.isValid(accessToken)).isTrue();
+	}
+
+
+
+	@Test
+	@DisplayName("AccessToken 응답으로 전송 - 성공")
+	public void successSendAccessAndRefreshToken() throws Exception {
+		//given
+		MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+
+		Long memberId = 1L;
+		JwtToken accessToken = jwtService.createAccessToken(memberId);
+
+
+		//when
+		jwtService.sendToken(mockHttpServletResponse, accessToken);
+
+
+		//then
+		String headerAccessToken = mockHttpServletResponse.getHeader(BEARER_HEADER);
+
+
+
+		assertThat(headerAccessToken).isEqualTo(accessToken.content());
+	}
+
+
+	@Test
+	@DisplayName("요청으로부터 AccessToken 추출 - 성공")
+	public void successExtractAccessToken() throws Exception {
+		//given
+		Long memberId = 1L;
+		JwtToken accessToken = jwtService.createAccessToken(memberId);
+		HttpServletRequest httpServletRequest = setRequest(accessToken);
+
+		//when
+		JwtToken extractAccessToken = jwtService.extractToken(httpServletRequest).orElseThrow(()-> new Exception("토큰이 없습니다"));
+
+
+		//then
+		assertThat(getVerify(extractAccessToken.content()).getClaim(JwtToken.MEMBER_ID_CLAIM).asLong()).isEqualTo(memberId);
+	}
+
+
+
+	@Test
+	@DisplayName("request -> 토큰 -> memberId 추출 - 성공")
+	public void successRequestToExtractMemberId() throws Exception { //TODO 메서드 이름 못짓겠어요
+		//given
+		Long memberId = 1L;
+		JwtToken accessToken = jwtService.createAccessToken(memberId);
+		HttpServletRequest httpServletRequest = setRequest(accessToken);
+
+		//when
+		JwtToken extractAccessToken = jwtService.extractToken(httpServletRequest).orElseThrow(()-> new Exception("토큰이 없습니다"));
+
+
+		//then
+		assertThat(getVerify(extractAccessToken.content()).getClaim(JwtToken.MEMBER_ID_CLAIM).asLong()).isEqualTo(memberId);
+	}
+
+}

--- a/src/test/java/com/footprint/member/service/MemberServiceTest.java
+++ b/src/test/java/com/footprint/member/service/MemberServiceTest.java
@@ -1,0 +1,89 @@
+package com.footprint.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.footprint.common.exception.BaseExceptionType;
+import com.footprint.member.domain.Member;
+import com.footprint.member.exception.MemberException;
+import com.footprint.member.exception.MemberExceptionType;
+import com.footprint.member.service.dto.CreateMemberDto;
+
+/**
+ * Created by ShinD on 2022/05/14.
+ */
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+
+	@Autowired EntityManager em;
+	@Autowired MemberService memberService;
+	@Autowired PasswordEncoder passwordEncoder;
+
+
+	@Test
+	@DisplayName("회원가입 - 성공")
+	public void successSignUp() throws Exception {
+	    //given
+		String username = "username";
+		String password = "password";
+		String nickName = "nickName";
+
+		CreateMemberDto createMemberDto = new CreateMemberDto(username, password, nickName);
+
+		//when
+		memberService.create(createMemberDto);
+
+		em.flush();
+		em.clear();
+
+	    //then
+		Member findMember = em.createQuery("SELECT m FROM Member m WHERE m.username = :username", Member.class)
+			.setParameter("username", username)
+			.getSingleResult();
+
+		assertThat(findMember).isNotNull();
+		assertThat(findMember.getId()).isNotNull();
+		assertThat(findMember.getNickname()).isEqualTo(nickName);
+		assertThat(passwordEncoder.matches(password, findMember.getPassword())).isTrue();
+		assertThat(findMember.getPassword()).startsWith("{bcrypt}");
+
+	}
+
+
+	@Test
+	@DisplayName("회원가입 - 실패 (원인 : 아이디 중복)")
+	public void failSignUpSinceDuplicatedUsername() throws Exception {
+		//given
+		String username = "username";
+		String password = "password";
+		String nickName = "nickName";
+
+		CreateMemberDto createMemberDto = new CreateMemberDto(username, password, nickName);
+		memberService.create(createMemberDto);
+		em.flush();
+		em.clear();
+
+		//when, then
+		BaseExceptionType exceptionType = assertThrows(MemberException.class,
+														() -> memberService.create(createMemberDto)).getExceptionType();
+
+		assertThat(exceptionType).isEqualTo(MemberExceptionType.DUPLICATE_USERNAME);
+		List<Member> members = em.createQuery("SELECT m FROM Member m", Member.class).getResultList();
+		assertThat(members.size()).isEqualTo(1);
+
+	}
+
+}


### PR DESCRIPTION
구현한 기능

- Spring Security 추가
- 회원가입 기능 구현
- Json으로 로그인하는 필터 구현 
- JWT를 사용하여 인증하는 필터 구현


TODO 

- JWT에 member의 pk(Id)만 가지도 있도록 하여, 이대로 배포할 경우 보안상 문제가 생길 수 있음 
    - 관련 method : JwtService의 createAccessToken
  
- SecurituConfig 의 .antMatchers("/login", "/signUp").permitAll()
    - url을 이렇게 관리할지, 필드로 따로 빼서 관리할지 고민

- JwtAuthenticationFilter가 Filter를 구현하는 경우 두번 작동하는 문제
    - OncePerRequestFilter를 상속받도록 하여 고쳤으나, Filter를 구현할 경우 왜 두번 작동하는지 모르겠음
    - 위의 원인은 해당 블로그를 참고 [https://pgnt.tistory.com/102, https://justforchangesake.wordpress.com/2014/05/07/spring-mvc-request-life-cycle/]

close #3 