### PR TITLE
[feature/main-travel > develop][#4] MainTravel 기본 기능 구현

### DIFF
--- a/src/main/java/com/footprint/common/exception/BaseException.java
+++ b/src/main/java/com/footprint/common/exception/BaseException.java
@@ -1,5 +1,5 @@
 package com.footprint.common.exception;
 
-public abstract class BaseException {
+public abstract class BaseException extends RuntimeException {
 	public abstract BaseExceptionType getExceptionType();
 }

--- a/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
+++ b/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
@@ -1,0 +1,58 @@
+package com.footprint.maintravel.controller;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.footprint.maintravel.controller.dto.MainTravelRequest;
+import com.footprint.maintravel.controller.dto.MainTravelResponse;
+import com.footprint.maintravel.service.MainTravelService;
+import com.footprint.maintravel.service.dto.MainTravelDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MainTravelController {
+	private final MainTravelService mainTravelService;
+
+	@GetMapping("/main-travels/{travelId}")
+	public ResponseEntity<MainTravelResponse> getMainTravel(@PathVariable Long travelId) {
+		MainTravelDto mainTravelDto = mainTravelService.getMainTravel(travelId);
+		return ResponseEntity.ok(MainTravelResponse.from(mainTravelDto));
+	}
+
+	@PatchMapping("/main-travels/{mainTravelId}")
+	public ResponseEntity<Long> saveMainTravel(@PathVariable Long mainTravelId,
+		@RequestBody MainTravelRequest updateRequest) {
+		Long updateMainTravelId = mainTravelService.updateMainTravel(updateRequest.toUpdateDto(mainTravelId));
+		return ResponseEntity.ok(updateMainTravelId);
+	}
+
+	@PostMapping("/main-travels")
+	public ResponseEntity<Long> saveMainTravel(@RequestBody MainTravelRequest saveRequest) {
+		Long saveMainTravelId = mainTravelService.saveMainTravel(saveRequest.toSaveDto());
+
+		URI location = ServletUriComponentsBuilder
+			.fromCurrentContextPath().path("/main-travels/")
+			.buildAndExpand(saveMainTravelId).toUri();
+
+		return ResponseEntity.created(location).body(saveMainTravelId);
+	}
+
+	@DeleteMapping("/main-travels/{mainTravelId}")
+	public ResponseEntity<Void> deleteMainTravel(@PathVariable Long mainTravelId) {
+		mainTravelService.deleteMainTravel(mainTravelId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
+++ b/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
@@ -26,14 +26,14 @@ import lombok.RequiredArgsConstructor;
 public class MainTravelController {
 	private final MainTravelService mainTravelService;
 
-	@GetMapping("/main-travels/{travelId}")
-	public ResponseEntity<MainTravelResponse> getMainTravel(@PathVariable Long travelId) {
-		MainTravelDto mainTravelDto = mainTravelService.getMainTravel(travelId);
+	@GetMapping("/main-travels/{mainTravelId}")
+	public ResponseEntity<MainTravelResponse> getMainTravel(@PathVariable Long mainTravelId) {
+		MainTravelDto mainTravelDto = mainTravelService.getMainTravel(mainTravelId);
 		return ResponseEntity.ok(MainTravelResponse.from(mainTravelDto));
 	}
 
 	@PatchMapping("/main-travels/{mainTravelId}")
-	public ResponseEntity<Long> saveMainTravel(@PathVariable Long mainTravelId,
+	public ResponseEntity<Long> updateMainTravel(@PathVariable Long mainTravelId,
 		@RequestBody MainTravelRequest updateRequest) {
 		Long updateMainTravelId = mainTravelService.updateMainTravel(updateRequest.toUpdateDto(mainTravelId));
 		return ResponseEntity.ok(updateMainTravelId);

--- a/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
+++ b/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
@@ -53,6 +53,6 @@ public class MainTravelController {
 	@DeleteMapping("/main-travels/{mainTravelId}")
 	public ResponseEntity<Void> deleteMainTravel(@PathVariable Long mainTravelId) {
 		mainTravelService.deleteMainTravel(mainTravelId);
-		return ResponseEntity.noContent().build();
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
+++ b/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
@@ -26,16 +26,16 @@ import lombok.RequiredArgsConstructor;
 public class MainTravelController {
 	private final MainTravelService mainTravelService;
 
-	@GetMapping("/main-travels/{mainTravelId}")
-	public ResponseEntity<MainTravelResponse> getMainTravel(@PathVariable Long mainTravelId) {
-		MainTravelDto mainTravelDto = mainTravelService.getMainTravel(mainTravelId);
+	@GetMapping("/main-travels/{id}")
+	public ResponseEntity<MainTravelResponse> getMainTravel(@PathVariable Long id) {
+		MainTravelDto mainTravelDto = mainTravelService.getMainTravel(id);
 		return ResponseEntity.ok(MainTravelResponse.from(mainTravelDto));
 	}
 
-	@PatchMapping("/main-travels/{mainTravelId}")
-	public ResponseEntity<Long> updateMainTravel(@PathVariable Long mainTravelId,
+	@PatchMapping("/main-travels/{id}")
+	public ResponseEntity<Long> updateMainTravel(@PathVariable Long id,
 		@RequestBody MainTravelRequest updateRequest) {
-		Long updateMainTravelId = mainTravelService.updateMainTravel(updateRequest.toUpdateDto(mainTravelId));
+		Long updateMainTravelId = mainTravelService.updateMainTravel(updateRequest.toUpdateDto(id));
 		return ResponseEntity.ok(updateMainTravelId);
 	}
 
@@ -50,9 +50,9 @@ public class MainTravelController {
 		return ResponseEntity.created(location).body(saveMainTravelId);
 	}
 
-	@DeleteMapping("/main-travels/{mainTravelId}")
-	public ResponseEntity<Void> deleteMainTravel(@PathVariable Long mainTravelId) {
-		mainTravelService.deleteMainTravel(mainTravelId);
+	@DeleteMapping("/main-travels/{id}")
+	public ResponseEntity<Void> deleteMainTravel(@PathVariable Long id) {
+		mainTravelService.deleteMainTravel(id);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
+++ b/src/main/java/com/footprint/maintravel/controller/MainTravelController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,7 +33,7 @@ public class MainTravelController {
 		return ResponseEntity.ok(MainTravelResponse.from(mainTravelDto));
 	}
 
-	@PatchMapping("/main-travels/{id}")
+	@PutMapping("/main-travels/{id}")
 	public ResponseEntity<Long> updateMainTravel(@PathVariable Long id,
 		@RequestBody MainTravelRequest updateRequest) {
 		Long updateMainTravelId = mainTravelService.updateMainTravel(updateRequest.toUpdateDto(id));

--- a/src/main/java/com/footprint/maintravel/controller/dto/MainTravelRequest.java
+++ b/src/main/java/com/footprint/maintravel/controller/dto/MainTravelRequest.java
@@ -1,0 +1,34 @@
+package com.footprint.maintravel.controller.dto;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import com.footprint.maintravel.service.dto.MainTravelSaveDto;
+import com.footprint.maintravel.service.dto.MainTravelUpdateDto;
+
+public record MainTravelRequest(
+	Boolean isCompleted,
+	String title,
+	String startDate,
+	String endDate,
+	Boolean isVisible
+) {
+	public MainTravelSaveDto toSaveDto() {
+		return new MainTravelSaveDto(
+			isCompleted(),
+			title(),
+			LocalDate.parse(startDate(), DateTimeFormatter.ISO_LOCAL_DATE),
+			LocalDate.parse(endDate(), DateTimeFormatter.ISO_LOCAL_DATE),
+			isVisible());
+	}
+
+	public MainTravelUpdateDto toUpdateDto(Long mainTravelId) {
+		return new MainTravelUpdateDto(
+			mainTravelId,
+			isCompleted(),
+			title(),
+			LocalDate.parse(startDate(), DateTimeFormatter.ISO_LOCAL_DATE),
+			LocalDate.parse(endDate(), DateTimeFormatter.ISO_LOCAL_DATE),
+			isVisible());
+	}
+}

--- a/src/main/java/com/footprint/maintravel/controller/dto/MainTravelResponse.java
+++ b/src/main/java/com/footprint/maintravel/controller/dto/MainTravelResponse.java
@@ -8,6 +8,7 @@ public record MainTravelResponse(
 	String startDate,
 	String endDate,
 	Boolean isVisible,
+	Boolean isCompleted,
 	Integer likeNum
 ) {
 	public static MainTravelResponse from(MainTravelDto mainTravelDto) {
@@ -17,6 +18,7 @@ public record MainTravelResponse(
 			mainTravelDto.startDate(),
 			mainTravelDto.endDate(),
 			mainTravelDto.isVisible(),
+			mainTravelDto.isCompleted(),
 			mainTravelDto.likeNum());
 	}
 }

--- a/src/main/java/com/footprint/maintravel/controller/dto/MainTravelResponse.java
+++ b/src/main/java/com/footprint/maintravel/controller/dto/MainTravelResponse.java
@@ -7,6 +7,7 @@ public record MainTravelResponse(
 	String title,
 	String startDate,
 	String endDate,
+	String createdAt,
 	Boolean isVisible,
 	Boolean isCompleted,
 	Integer likeNum
@@ -17,6 +18,7 @@ public record MainTravelResponse(
 			mainTravelDto.title(),
 			mainTravelDto.startDate(),
 			mainTravelDto.endDate(),
+			mainTravelDto.createdAt(),
 			mainTravelDto.isVisible(),
 			mainTravelDto.isCompleted(),
 			mainTravelDto.likeNum());

--- a/src/main/java/com/footprint/maintravel/controller/dto/MainTravelResponse.java
+++ b/src/main/java/com/footprint/maintravel/controller/dto/MainTravelResponse.java
@@ -7,7 +7,7 @@ public record MainTravelResponse(
 	String title,
 	String startDate,
 	String endDate,
-	Boolean isVisited,
+	Boolean isVisible,
 	Integer likeNum
 ) {
 	public static MainTravelResponse from(MainTravelDto mainTravelDto) {
@@ -16,7 +16,7 @@ public record MainTravelResponse(
 			mainTravelDto.title(),
 			mainTravelDto.startDate(),
 			mainTravelDto.endDate(),
-			mainTravelDto.isVisited(),
+			mainTravelDto.isVisible(),
 			mainTravelDto.likeNum());
 	}
 }

--- a/src/main/java/com/footprint/maintravel/controller/dto/MainTravelResponse.java
+++ b/src/main/java/com/footprint/maintravel/controller/dto/MainTravelResponse.java
@@ -1,0 +1,22 @@
+package com.footprint.maintravel.controller.dto;
+
+import com.footprint.maintravel.service.dto.MainTravelDto;
+
+public record MainTravelResponse(
+	Long id,
+	String title,
+	String startDate,
+	String endDate,
+	Boolean isVisited,
+	Integer likeNum
+) {
+	public static MainTravelResponse from(MainTravelDto mainTravelDto) {
+		return new MainTravelResponse(
+			mainTravelDto.id(),
+			mainTravelDto.title(),
+			mainTravelDto.startDate(),
+			mainTravelDto.endDate(),
+			mainTravelDto.isVisited(),
+			mainTravelDto.likeNum());
+	}
+}

--- a/src/main/java/com/footprint/maintravel/domain/MainTravel.java
+++ b/src/main/java/com/footprint/maintravel/domain/MainTravel.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -57,7 +58,6 @@ public class MainTravel {
 	@Column(name = "is_completed", nullable = false)
 	private boolean isCompleted;
 
-
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "image_id")
 	private Image image;
@@ -65,7 +65,6 @@ public class MainTravel {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member writer;
-
 
 	@OneToMany(mappedBy = "mainTravel", orphanRemoval = true, cascade = CascadeType.ALL)
 	private List<Comment> comments = new ArrayList<>();
@@ -79,4 +78,21 @@ public class MainTravel {
 	@OneToMany(mappedBy = "mainTravel", orphanRemoval = true, cascade = CascadeType.ALL)
 	private List<Heart> hearts = new ArrayList<>();
 
+	@Builder
+	public MainTravel(String title, LocalDate startDate, LocalDate endDate, Boolean isVisible, Boolean isCompleted) {
+		this.title = title;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.isVisible = isVisible;
+		this.isCompleted = isCompleted;
+		this.likeNum = 0;
+	}
+
+	public void update(String title, LocalDate startDate, LocalDate endDate, Boolean isVisible, Boolean isCompleted) {
+		this.title = title;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.isVisible = isVisible;
+		this.isCompleted = isCompleted;
+	}
 }

--- a/src/main/java/com/footprint/maintravel/domain/MainTravel.java
+++ b/src/main/java/com/footprint/maintravel/domain/MainTravel.java
@@ -23,6 +23,7 @@ import javax.persistence.Table;
 import javax.persistence.Id;
 
 import com.footprint.comment.domain.Comment;
+import com.footprint.common.BaseTimeEntity;
 import com.footprint.detailedtravel.domain.DetailTravel;
 import com.footprint.heart.domain.Heart;
 import com.footprint.image.domain.Image;
@@ -33,7 +34,7 @@ import com.footprint.scrap.domain.Scrap;
 @Table(name = "main_travel")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class MainTravel {
+public class MainTravel extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "main_travel_id")

--- a/src/main/java/com/footprint/maintravel/exception/MainTravelException.java
+++ b/src/main/java/com/footprint/maintravel/exception/MainTravelException.java
@@ -1,0 +1,17 @@
+package com.footprint.maintravel.exception;
+
+import com.footprint.common.exception.BaseException;
+import com.footprint.common.exception.BaseExceptionType;
+
+public class MainTravelException extends BaseException {
+	private final MainTravelExceptionType mainTravelExceptionType;
+
+	public MainTravelException(MainTravelExceptionType mainTravelExceptionType) {
+		this.mainTravelExceptionType = mainTravelExceptionType;
+	}
+
+	@Override
+	public BaseExceptionType getExceptionType() {
+		return mainTravelExceptionType;
+	}
+}

--- a/src/main/java/com/footprint/maintravel/exception/MainTravelExceptionType.java
+++ b/src/main/java/com/footprint/maintravel/exception/MainTravelExceptionType.java
@@ -1,0 +1,34 @@
+package com.footprint.maintravel.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.footprint.common.exception.BaseExceptionType;
+
+public enum MainTravelExceptionType implements BaseExceptionType {
+	NOT_FOUND(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND, "해당 여행 게시글이 존재하지 않습니다.");
+
+	private final int errorCode;
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+
+	MainTravelExceptionType(int errorCode, HttpStatus httpStatus, String errorMessage) {
+		this.errorCode = errorCode;
+		this.httpStatus = httpStatus;
+		this.errorMessage = errorMessage;
+	}
+
+	@Override
+	public int getErrorCode() {
+		return this.errorCode;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return this.httpStatus;
+	}
+
+	@Override
+	public String getErrorMessage() {
+		return this.errorMessage;
+	}
+}

--- a/src/main/java/com/footprint/maintravel/repository/MainTravelRepository.java
+++ b/src/main/java/com/footprint/maintravel/repository/MainTravelRepository.java
@@ -1,0 +1,8 @@
+package com.footprint.maintravel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.footprint.maintravel.domain.MainTravel;
+
+public interface MainTravelRepository extends JpaRepository<MainTravel, Long> {
+}

--- a/src/main/java/com/footprint/maintravel/service/MainTravelService.java
+++ b/src/main/java/com/footprint/maintravel/service/MainTravelService.java
@@ -1,0 +1,16 @@
+package com.footprint.maintravel.service;
+
+import com.footprint.maintravel.service.dto.MainTravelDto;
+import com.footprint.maintravel.service.dto.MainTravelSaveDto;
+import com.footprint.maintravel.service.dto.MainTravelUpdateDto;
+
+public interface MainTravelService {
+
+	Long saveMainTravel(MainTravelSaveDto saveDto);
+
+	Long updateMainTravel(MainTravelUpdateDto updateDto);
+
+	MainTravelDto getMainTravel(Long travelId);
+
+	void deleteMainTravel(Long mainTravelId);
+}

--- a/src/main/java/com/footprint/maintravel/service/MainTravelServiceImpl.java
+++ b/src/main/java/com/footprint/maintravel/service/MainTravelServiceImpl.java
@@ -30,13 +30,7 @@ public class MainTravelServiceImpl implements MainTravelService {
 
 	@Override
 	public Long saveMainTravel(MainTravelSaveDto saveDto) {
-		MainTravel save = mainTravelRepository.save(MainTravel.builder()
-			.title(saveDto.title())
-			.startDate(saveDto.startDate())
-			.endDate(saveDto.endDate())
-			.isCompleted(saveDto.isCompleted())
-			.isVisible(saveDto.isVisible())
-			.build());
+		MainTravel save = mainTravelRepository.save(saveDto.toEntity());
 		return save.getId();
 	}
 

--- a/src/main/java/com/footprint/maintravel/service/MainTravelServiceImpl.java
+++ b/src/main/java/com/footprint/maintravel/service/MainTravelServiceImpl.java
@@ -1,0 +1,59 @@
+package com.footprint.maintravel.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.footprint.maintravel.controller.dto.MainTravelResponse;
+import com.footprint.maintravel.domain.MainTravel;
+import com.footprint.maintravel.exception.MainTravelException;
+import com.footprint.maintravel.exception.MainTravelExceptionType;
+import com.footprint.maintravel.repository.MainTravelRepository;
+import com.footprint.maintravel.service.dto.MainTravelDto;
+import com.footprint.maintravel.service.dto.MainTravelSaveDto;
+import com.footprint.maintravel.service.dto.MainTravelUpdateDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MainTravelServiceImpl implements MainTravelService {
+	private final MainTravelRepository mainTravelRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public MainTravelDto getMainTravel(Long travelId) {
+		MainTravel mainTravel = mainTravelRepository.findById(travelId)
+			.orElseThrow(() -> new MainTravelException(MainTravelExceptionType.NOT_FOUND));
+		return MainTravelDto.from(mainTravel);
+	}
+
+	@Override
+	public Long saveMainTravel(MainTravelSaveDto saveDto) {
+		MainTravel save = mainTravelRepository.save(MainTravel.builder()
+			.title(saveDto.title())
+			.startDate(saveDto.startDate())
+			.endDate(saveDto.endDate())
+			.isCompleted(saveDto.isCompleted())
+			.isVisible(saveDto.isVisible())
+			.build());
+		return save.getId();
+	}
+
+	@Override
+	public Long updateMainTravel(MainTravelUpdateDto updateDto) {
+		MainTravel mainTravel = mainTravelRepository.findById(updateDto.id())
+			.orElseThrow(() -> new MainTravelException(MainTravelExceptionType.NOT_FOUND));
+		mainTravel.update(updateDto.title(), updateDto.startDate(), updateDto.endDate(), updateDto.isVisible(),
+			updateDto.isCompleted());
+		return mainTravel.getId();
+	}
+
+	@Override
+	public void deleteMainTravel(Long mainTravelId) {
+		MainTravel mainTravel = mainTravelRepository.findById(mainTravelId).orElseThrow();
+		mainTravelRepository.delete(mainTravel);
+	}
+}

--- a/src/main/java/com/footprint/maintravel/service/MainTravelServiceImpl.java
+++ b/src/main/java/com/footprint/maintravel/service/MainTravelServiceImpl.java
@@ -1,14 +1,12 @@
 package com.footprint.maintravel.service;
 
-import java.util.Optional;
+import static com.footprint.maintravel.exception.MainTravelExceptionType.*;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.footprint.maintravel.controller.dto.MainTravelResponse;
 import com.footprint.maintravel.domain.MainTravel;
 import com.footprint.maintravel.exception.MainTravelException;
-import com.footprint.maintravel.exception.MainTravelExceptionType;
 import com.footprint.maintravel.repository.MainTravelRepository;
 import com.footprint.maintravel.service.dto.MainTravelDto;
 import com.footprint.maintravel.service.dto.MainTravelSaveDto;
@@ -26,7 +24,7 @@ public class MainTravelServiceImpl implements MainTravelService {
 	@Transactional(readOnly = true)
 	public MainTravelDto getMainTravel(Long travelId) {
 		MainTravel mainTravel = mainTravelRepository.findById(travelId)
-			.orElseThrow(() -> new MainTravelException(MainTravelExceptionType.NOT_FOUND));
+			.orElseThrow(() -> new MainTravelException(NOT_FOUND));
 		return MainTravelDto.from(mainTravel);
 	}
 
@@ -45,7 +43,7 @@ public class MainTravelServiceImpl implements MainTravelService {
 	@Override
 	public Long updateMainTravel(MainTravelUpdateDto updateDto) {
 		MainTravel mainTravel = mainTravelRepository.findById(updateDto.id())
-			.orElseThrow(() -> new MainTravelException(MainTravelExceptionType.NOT_FOUND));
+			.orElseThrow(() -> new MainTravelException(NOT_FOUND));
 		mainTravel.update(updateDto.title(), updateDto.startDate(), updateDto.endDate(), updateDto.isVisible(),
 			updateDto.isCompleted());
 		return mainTravel.getId();
@@ -53,7 +51,8 @@ public class MainTravelServiceImpl implements MainTravelService {
 
 	@Override
 	public void deleteMainTravel(Long mainTravelId) {
-		MainTravel mainTravel = mainTravelRepository.findById(mainTravelId).orElseThrow();
+		MainTravel mainTravel = mainTravelRepository.findById(mainTravelId)
+			.orElseThrow(() -> new MainTravelException(NOT_FOUND));
 		mainTravelRepository.delete(mainTravel);
 	}
 }

--- a/src/main/java/com/footprint/maintravel/service/dto/MainTravelDto.java
+++ b/src/main/java/com/footprint/maintravel/service/dto/MainTravelDto.java
@@ -7,7 +7,7 @@ public record MainTravelDto(
 	String title,
 	String startDate,
 	String endDate,
-	Boolean isVisited,
+	Boolean isVisible,
 	Integer likeNum
 ) {
 	public static MainTravelDto from(MainTravel mainTravel) {

--- a/src/main/java/com/footprint/maintravel/service/dto/MainTravelDto.java
+++ b/src/main/java/com/footprint/maintravel/service/dto/MainTravelDto.java
@@ -1,0 +1,23 @@
+package com.footprint.maintravel.service.dto;
+
+import com.footprint.maintravel.domain.MainTravel;
+
+public record MainTravelDto(
+	Long id,
+	String title,
+	String startDate,
+	String endDate,
+	Boolean isVisited,
+	Integer likeNum
+) {
+	public static MainTravelDto from(MainTravel mainTravel) {
+		return new MainTravelDto(
+			mainTravel.getId(),
+			mainTravel.getTitle(),
+			mainTravel.getStartDate().toString(),
+			mainTravel.getEndDate().toString(),
+			mainTravel.getIsVisible(),
+			mainTravel.getLikeNum()
+		);
+	}
+}

--- a/src/main/java/com/footprint/maintravel/service/dto/MainTravelDto.java
+++ b/src/main/java/com/footprint/maintravel/service/dto/MainTravelDto.java
@@ -1,5 +1,7 @@
 package com.footprint.maintravel.service.dto;
 
+import java.time.format.DateTimeFormatter;
+
 import com.footprint.maintravel.domain.MainTravel;
 
 public record MainTravelDto(
@@ -7,6 +9,7 @@ public record MainTravelDto(
 	String title,
 	String startDate,
 	String endDate,
+	String createdAt,
 	Boolean isVisible,
 	Boolean isCompleted,
 	Integer likeNum
@@ -17,6 +20,7 @@ public record MainTravelDto(
 			mainTravel.getTitle(),
 			mainTravel.getStartDate().toString(),
 			mainTravel.getEndDate().toString(),
+			mainTravel.getCreatedAt().toString(),
 			mainTravel.getIsVisible(),
 			mainTravel.isCompleted(),
 			mainTravel.getLikeNum()

--- a/src/main/java/com/footprint/maintravel/service/dto/MainTravelDto.java
+++ b/src/main/java/com/footprint/maintravel/service/dto/MainTravelDto.java
@@ -8,6 +8,7 @@ public record MainTravelDto(
 	String startDate,
 	String endDate,
 	Boolean isVisible,
+	Boolean isCompleted,
 	Integer likeNum
 ) {
 	public static MainTravelDto from(MainTravel mainTravel) {
@@ -17,6 +18,7 @@ public record MainTravelDto(
 			mainTravel.getStartDate().toString(),
 			mainTravel.getEndDate().toString(),
 			mainTravel.getIsVisible(),
+			mainTravel.isCompleted(),
 			mainTravel.getLikeNum()
 		);
 	}

--- a/src/main/java/com/footprint/maintravel/service/dto/MainTravelSaveDto.java
+++ b/src/main/java/com/footprint/maintravel/service/dto/MainTravelSaveDto.java
@@ -2,10 +2,22 @@ package com.footprint.maintravel.service.dto;
 
 import java.time.LocalDate;
 
+import com.footprint.maintravel.domain.MainTravel;
+
 public record MainTravelSaveDto(
 	Boolean isCompleted,
 	String title,
 	LocalDate startDate,
 	LocalDate endDate,
 	Boolean isVisible) {
+
+	public MainTravel toEntity() {
+		return MainTravel.builder()
+			.title(title())
+			.startDate(startDate())
+			.endDate(endDate())
+			.isCompleted(isCompleted())
+			.isVisible(isVisible())
+			.build();
+	}
 }

--- a/src/main/java/com/footprint/maintravel/service/dto/MainTravelSaveDto.java
+++ b/src/main/java/com/footprint/maintravel/service/dto/MainTravelSaveDto.java
@@ -1,0 +1,11 @@
+package com.footprint.maintravel.service.dto;
+
+import java.time.LocalDate;
+
+public record MainTravelSaveDto(
+	Boolean isCompleted,
+	String title,
+	LocalDate startDate,
+	LocalDate endDate,
+	Boolean isVisible) {
+}

--- a/src/main/java/com/footprint/maintravel/service/dto/MainTravelUpdateDto.java
+++ b/src/main/java/com/footprint/maintravel/service/dto/MainTravelUpdateDto.java
@@ -1,0 +1,14 @@
+package com.footprint.maintravel.service.dto;
+
+import java.time.LocalDate;
+
+public record MainTravelUpdateDto(
+	Long id,
+	Boolean isCompleted,
+	String title,
+	LocalDate startDate,
+	LocalDate endDate,
+	Boolean isVisible
+) {
+
+}

--- a/src/test/java/com/footprint/maintravel/controller/MainTravelControllerTest.java
+++ b/src/test/java/com/footprint/maintravel/controller/MainTravelControllerTest.java
@@ -1,0 +1,101 @@
+package com.footprint.maintravel.controller;
+
+import static com.footprint.maintravel.fixture.MainTravelFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.footprint.maintravel.service.MainTravelService;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(controllers = MainTravelController.class)
+class MainTravelControllerTest {
+	//TODO @RestControllerAdvice 생성 후 실패 테스트 작성
+
+	@MockBean
+	private MainTravelService mainTravelService;
+
+	private MockMvc mockMvc;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@BeforeEach
+	private void setUp(WebApplicationContext webApplicationContext) {
+		mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+	}
+
+	@Test
+	@DisplayName("MainTravel 단일 조회 성공 테스트")
+	void getMainTravelSuccessTest() throws Exception {
+		//given
+		given(mainTravelService.getMainTravel(MAIN_TRAVEL_ID)).willReturn(getMainTravelDto());
+		String content = objectMapper.writeValueAsString(getMainTravelDto());
+
+		//when
+		MvcResult result = mockMvc.perform(get("/api/main-travels/{mainTravelId}", MAIN_TRAVEL_ID)
+				.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		//then
+		assertEquals(content, result.getResponse().getContentAsString());
+	}
+
+	@Test
+	@DisplayName("MainTravel 저장 성공 테스트")
+	void saveMainTravelSuccessTest() throws Exception {
+		//given
+		given(mainTravelService.saveMainTravel(any())).willReturn(MAIN_TRAVEL_ID);
+
+		//when
+		MvcResult result = mockMvc.perform(post("/api/main-travels")
+				.content(objectMapper.writeValueAsString(getMainTravelRequest()))
+				.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isCreated())
+			.andReturn();
+
+		//then
+		assertEquals(String.valueOf(MAIN_TRAVEL_ID), result.getResponse().getContentAsString());
+	}
+
+	@Test
+	@DisplayName("MainTravel 수정 성공 테스트")
+	void updateMainTravelSuccessTest() throws Exception {
+		//given
+		given(mainTravelService.updateMainTravel(any())).willReturn(MAIN_TRAVEL_ID);
+
+		//when
+		MvcResult result = mockMvc.perform(patch("/api/main-travels/{mainTravelId}", MAIN_TRAVEL_ID)
+				.content(objectMapper.writeValueAsString(getMainTravelRequest()))
+				.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		//then
+		assertEquals(String.valueOf(MAIN_TRAVEL_ID), result.getResponse().getContentAsString());
+	}
+
+	@Test
+	@DisplayName("MainTravel 삭제 성공 테스트")
+	void deleteMainTravelSuccessTest() throws Exception {
+		MvcResult result = mockMvc.perform(delete("/api/main-travels/{mainTravelId}", MAIN_TRAVEL_ID)
+				.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNoContent())
+			.andReturn();
+	}
+}

--- a/src/test/java/com/footprint/maintravel/controller/MainTravelControllerTest.java
+++ b/src/test/java/com/footprint/maintravel/controller/MainTravelControllerTest.java
@@ -80,7 +80,7 @@ class MainTravelControllerTest {
 		given(mainTravelService.updateMainTravel(any())).willReturn(MAIN_TRAVEL_ID);
 
 		//when
-		MvcResult result = mockMvc.perform(patch("/api/main-travels/{mainTravelId}", MAIN_TRAVEL_ID)
+		MvcResult result = mockMvc.perform(put("/api/main-travels/{mainTravelId}", MAIN_TRAVEL_ID)
 				.content(objectMapper.writeValueAsString(getMainTravelRequest()))
 				.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -95,7 +95,7 @@ class MainTravelControllerTest {
 	void deleteMainTravelSuccessTest() throws Exception {
 		MvcResult result = mockMvc.perform(delete("/api/main-travels/{mainTravelId}", MAIN_TRAVEL_ID)
 				.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
-			.andExpect(status().isNoContent())
+			.andExpect(status().isOk())
 			.andReturn();
 	}
 }

--- a/src/test/java/com/footprint/maintravel/controller/dto/MainTravelRequestTest.java
+++ b/src/test/java/com/footprint/maintravel/controller/dto/MainTravelRequestTest.java
@@ -1,0 +1,71 @@
+package com.footprint.maintravel.controller.dto;
+
+import static com.footprint.maintravel.fixture.MainTravelFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.footprint.maintravel.service.dto.MainTravelSaveDto;
+import com.footprint.maintravel.service.dto.MainTravelUpdateDto;
+
+class MainTravelRequestTest {
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private static final String REQUEST_BODY = "{\n" +
+		"\"isCompleted\":true,\n" +
+		"\"title\":\"title\",\n" +
+		"\"startDate\":\"2022-03-15\",\n" +
+		"\"endDate\":\"2022-03-17\",\n" +
+		"\"isVisible\":true\n" +
+		"}";
+
+	@Test
+	@DisplayName("MainTravelRequest 변환 테스트")
+	void mainTravelRequestTest() throws Exception {
+		//given, when
+		MainTravelRequest mainTravelRequest = objectMapper.readValue(REQUEST_BODY, MainTravelRequest.class);
+
+		//then
+		assertEquals(getMainTravelRequest().title(), mainTravelRequest.title());
+		assertEquals(getMainTravelRequest().isCompleted(), mainTravelRequest.isCompleted());
+		assertEquals(getMainTravelRequest().startDate(), mainTravelRequest.startDate());
+		assertEquals(getMainTravelRequest().endDate(), mainTravelRequest.endDate());
+		assertEquals(getMainTravelRequest().isVisible(), mainTravelRequest.isVisible());
+	}
+
+	@Test
+	@DisplayName("MainTravelSaveDto 변환 테스트")
+	void toSaveDtoTest() throws Exception {
+		//given
+		MainTravelRequest mainTravelRequest = objectMapper.readValue(REQUEST_BODY, MainTravelRequest.class);
+
+		//when
+		MainTravelSaveDto mainTravelSaveDto = mainTravelRequest.toSaveDto();
+
+		//then
+		assertEquals(getMainTravelSaveDto().title(), mainTravelSaveDto.title());
+		assertEquals(getMainTravelSaveDto().isCompleted(), mainTravelSaveDto.isCompleted());
+		assertEquals(getMainTravelSaveDto().startDate(), mainTravelSaveDto.startDate());
+		assertEquals(getMainTravelSaveDto().endDate(), mainTravelSaveDto.endDate());
+		assertEquals(getMainTravelSaveDto().isVisible(), mainTravelSaveDto.isVisible());
+	}
+
+	@Test
+	@DisplayName("MainTravelUpdateDto 변환 테스트")
+	void toUpdateDtoTest() throws Exception {
+		//given
+		MainTravelRequest mainTravelRequest = objectMapper.readValue(REQUEST_BODY, MainTravelRequest.class);
+
+		//when
+		MainTravelUpdateDto mainTravelUpdateDto = mainTravelRequest.toUpdateDto(MAIN_TRAVEL_ID);
+
+		//then
+		assertEquals(getMainTravelUpdateDto(MAIN_TRAVEL_ID).id(), mainTravelUpdateDto.id());
+		assertEquals(getMainTravelUpdateDto(MAIN_TRAVEL_ID).title(), mainTravelUpdateDto.title());
+		assertEquals(getMainTravelUpdateDto(MAIN_TRAVEL_ID).isCompleted(), mainTravelUpdateDto.isCompleted());
+		assertEquals(getMainTravelUpdateDto(MAIN_TRAVEL_ID).startDate(), mainTravelUpdateDto.startDate());
+		assertEquals(getMainTravelUpdateDto(MAIN_TRAVEL_ID).endDate(), mainTravelUpdateDto.endDate());
+		assertEquals(getMainTravelUpdateDto(MAIN_TRAVEL_ID).isVisible(), mainTravelUpdateDto.isVisible());
+	}
+}

--- a/src/test/java/com/footprint/maintravel/controller/dto/MainTravelResponseTest.java
+++ b/src/test/java/com/footprint/maintravel/controller/dto/MainTravelResponseTest.java
@@ -15,6 +15,7 @@ class MainTravelResponseTest {
 		"\"title\":\"title\"," +
 		"\"startDate\":\"2022-03-15\"," +
 		"\"endDate\":\"2022-03-17\"," +
+		"\"createdAt\":\"2022-03-18T10:10\"," +
 		"\"isVisible\":true," +
 		"\"isCompleted\":true," +
 		"\"likeNum\":0" +

--- a/src/test/java/com/footprint/maintravel/controller/dto/MainTravelResponseTest.java
+++ b/src/test/java/com/footprint/maintravel/controller/dto/MainTravelResponseTest.java
@@ -1,0 +1,38 @@
+package com.footprint.maintravel.controller.dto;
+
+import static com.footprint.maintravel.fixture.MainTravelFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class MainTravelResponseTest {
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private static final String EXPECT = "{" +
+		"\"id\":1," +
+		"\"title\":\"title\"," +
+		"\"startDate\":\"2022-03-15\"," +
+		"\"endDate\":\"2022-03-17\"," +
+		"\"isVisible\":true," +
+		"\"isCompleted\":true," +
+		"\"likeNum\":0" +
+		"}";
+
+	@Test
+	@DisplayName("mainTravelResponse 변환 테스트")
+	void mainTravelResponseTest() throws Exception {
+		assertEquals(EXPECT, objectMapper.writeValueAsString(getMainTravelResponse()));
+	}
+
+	@Test
+	@DisplayName("Service mainTravelDto에서 mainTravelResponse 로 변환 테스트")
+	void fromTest() throws Exception {
+		//given, when
+		MainTravelResponse mainTravelResponse = MainTravelResponse.from(getMainTravelDto());
+
+		//then
+		assertEquals(EXPECT, objectMapper.writeValueAsString(mainTravelResponse));
+	}
+}

--- a/src/test/java/com/footprint/maintravel/fixture/MainTravelFixture.java
+++ b/src/test/java/com/footprint/maintravel/fixture/MainTravelFixture.java
@@ -1,0 +1,60 @@
+package com.footprint.maintravel.fixture;
+
+import java.time.LocalDate;
+
+import com.footprint.maintravel.controller.dto.MainTravelRequest;
+import com.footprint.maintravel.controller.dto.MainTravelResponse;
+import com.footprint.maintravel.domain.MainTravel;
+import com.footprint.maintravel.service.dto.MainTravelDto;
+import com.footprint.maintravel.service.dto.MainTravelSaveDto;
+import com.footprint.maintravel.service.dto.MainTravelUpdateDto;
+
+public class MainTravelFixture {
+	public static final Long MAIN_TRAVEL_ID = 1L;
+	public static final String TITLE = "title";
+	public static final String UPDATE_TITLE = "update-title";
+	public static final String START_DATE_STRING = "2022-03-15";
+	public static final LocalDate START_DATE = LocalDate.parse(START_DATE_STRING);
+	public static final String END_DATE_STRING = "2022-03-17";
+	public static final LocalDate END_DATE = LocalDate.parse(END_DATE_STRING);
+	public static final Boolean IS_VISIBLE = true;
+	public static final Boolean IS_COMPLETED = true;
+	public static final int LIKE_NUM = 0;
+
+	public static MainTravel getMainTravel() {
+		return MainTravel.builder()
+			.title(TITLE)
+			.startDate(START_DATE)
+			.endDate(END_DATE)
+			.isVisible(IS_VISIBLE)
+			.isCompleted(IS_COMPLETED)
+			.build();
+
+	}
+
+	public static MainTravelRequest getMainTravelRequest() {
+		return new MainTravelRequest(IS_COMPLETED, TITLE, START_DATE_STRING, END_DATE_STRING, IS_VISIBLE);
+	}
+
+	public static MainTravelResponse getMainTravelResponse() {
+		return new MainTravelResponse(MAIN_TRAVEL_ID, TITLE, START_DATE_STRING, END_DATE_STRING, IS_VISIBLE,
+			IS_COMPLETED, LIKE_NUM);
+	}
+
+	public static MainTravelDto getMainTravelDto() {
+		return new MainTravelDto(MAIN_TRAVEL_ID, TITLE, START_DATE_STRING, END_DATE_STRING, IS_VISIBLE, IS_COMPLETED,
+			LIKE_NUM);
+	}
+
+	public static MainTravelSaveDto getMainTravelSaveDto() {
+		return new MainTravelSaveDto(IS_COMPLETED, TITLE, START_DATE, END_DATE, IS_VISIBLE);
+	}
+
+	public static MainTravelUpdateDto getMainTravelUpdateDto() {
+		return new MainTravelUpdateDto(MAIN_TRAVEL_ID, IS_COMPLETED, UPDATE_TITLE, START_DATE, END_DATE, IS_VISIBLE);
+	}
+
+	public static MainTravelUpdateDto getMainTravelUpdateDto(Long mainTravelId) {
+		return getMainTravelRequest().toUpdateDto(mainTravelId);
+	}
+}

--- a/src/test/java/com/footprint/maintravel/fixture/MainTravelFixture.java
+++ b/src/test/java/com/footprint/maintravel/fixture/MainTravelFixture.java
@@ -1,6 +1,9 @@
 package com.footprint.maintravel.fixture;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.footprint.maintravel.controller.dto.MainTravelRequest;
 import com.footprint.maintravel.controller.dto.MainTravelResponse;
@@ -17,19 +20,22 @@ public class MainTravelFixture {
 	public static final LocalDate START_DATE = LocalDate.parse(START_DATE_STRING);
 	public static final String END_DATE_STRING = "2022-03-17";
 	public static final LocalDate END_DATE = LocalDate.parse(END_DATE_STRING);
+	public static final LocalDateTime CREATED_AT = LocalDateTime.of(2022, 3, 18, 10, 10);
+	public static final String CREATED_AT_STRING = CREATED_AT.toString();
 	public static final Boolean IS_VISIBLE = true;
 	public static final Boolean IS_COMPLETED = true;
 	public static final int LIKE_NUM = 0;
 
 	public static MainTravel getMainTravel() {
-		return MainTravel.builder()
+		MainTravel mainTravel = MainTravel.builder()
 			.title(TITLE)
 			.startDate(START_DATE)
 			.endDate(END_DATE)
 			.isVisible(IS_VISIBLE)
 			.isCompleted(IS_COMPLETED)
 			.build();
-
+		ReflectionTestUtils.setField(mainTravel, "createdAt", CREATED_AT);
+		return mainTravel;
 	}
 
 	public static MainTravelRequest getMainTravelRequest() {
@@ -37,13 +43,13 @@ public class MainTravelFixture {
 	}
 
 	public static MainTravelResponse getMainTravelResponse() {
-		return new MainTravelResponse(MAIN_TRAVEL_ID, TITLE, START_DATE_STRING, END_DATE_STRING, IS_VISIBLE,
-			IS_COMPLETED, LIKE_NUM);
+		return new MainTravelResponse(MAIN_TRAVEL_ID, TITLE, START_DATE_STRING, END_DATE_STRING, CREATED_AT_STRING,
+			IS_VISIBLE, IS_COMPLETED, LIKE_NUM);
 	}
 
 	public static MainTravelDto getMainTravelDto() {
-		return new MainTravelDto(MAIN_TRAVEL_ID, TITLE, START_DATE_STRING, END_DATE_STRING, IS_VISIBLE, IS_COMPLETED,
-			LIKE_NUM);
+		return new MainTravelDto(MAIN_TRAVEL_ID, TITLE, START_DATE_STRING, END_DATE_STRING, CREATED_AT_STRING,
+			IS_VISIBLE, IS_COMPLETED, LIKE_NUM);
 	}
 
 	public static MainTravelSaveDto getMainTravelSaveDto() {

--- a/src/test/java/com/footprint/maintravel/service/MainTravelServiceTest.java
+++ b/src/test/java/com/footprint/maintravel/service/MainTravelServiceTest.java
@@ -1,0 +1,102 @@
+package com.footprint.maintravel.service;
+
+import static com.footprint.maintravel.fixture.MainTravelFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.footprint.maintravel.domain.MainTravel;
+import com.footprint.maintravel.exception.MainTravelException;
+import com.footprint.maintravel.repository.MainTravelRepository;
+import com.footprint.maintravel.service.dto.MainTravelDto;
+
+@ExtendWith(MockitoExtension.class)
+class MainTravelServiceTest {
+	private final MainTravelRepository mainTravelRepository = mock(MainTravelRepository.class);
+
+	@InjectMocks
+	private MainTravelService mainTravelService = new MainTravelServiceImpl(mainTravelRepository);
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	@DisplayName("성공적으로 MainTravel을 불러오는지 테스트")
+	void getMainTravelSuccessTest() throws Exception {
+		//given
+		given(mainTravelRepository.findById(MAIN_TRAVEL_ID)).willReturn(Optional.of(getMainTravel()));
+
+		//when
+		MainTravelDto mainTravelDto = mainTravelService.getMainTravel(MAIN_TRAVEL_ID);
+
+		//then
+		assertEquals(getMainTravelDto().title(), mainTravelDto.title());
+		assertEquals(getMainTravelDto().startDate(), mainTravelDto.startDate());
+		assertEquals(getMainTravelDto().endDate(), mainTravelDto.endDate());
+		assertEquals(getMainTravelDto().isVisible(), mainTravelDto.isVisible());
+		assertEquals(getMainTravelDto().isCompleted(), mainTravelDto.isCompleted());
+	}
+
+	@Test
+	@DisplayName("찾으려는 MainTravel이 존재하지 않을 때 테스트")
+	void getMainTravelFailTest() throws Exception {
+		//given
+		given(mainTravelRepository.findById(MAIN_TRAVEL_ID)).willReturn(Optional.empty());
+
+		//when, then
+		assertThrows(MainTravelException.class, () -> mainTravelService.getMainTravel(MAIN_TRAVEL_ID));
+	}
+
+	@Test
+	@DisplayName("MainTravel 저장 성공 테스트")
+	void saveMainTravelSuccessTest() throws Exception {
+		//given
+		MainTravel mainTravel = getMainTravel();
+		ReflectionTestUtils.setField(mainTravel, "id", MAIN_TRAVEL_ID);
+		given(mainTravelRepository.save(any())).willReturn(mainTravel);
+
+		//when
+		Long savedMainTravelId = mainTravelService.saveMainTravel(getMainTravelSaveDto());
+
+		//then
+		assertEquals(MAIN_TRAVEL_ID, savedMainTravelId);
+	}
+
+	@Test
+	@DisplayName("MainTravel 수정 성공 테스트")
+	void updateMainTravelSuccessTest() throws Exception {
+		//given
+		MainTravel mainTravel = getMainTravel();
+		ReflectionTestUtils.setField(mainTravel, "id", MAIN_TRAVEL_ID);
+		given(mainTravelRepository.findById(MAIN_TRAVEL_ID)).willReturn(Optional.of(mainTravel));
+
+		//when
+		Long savedMainTravelId = mainTravelService.updateMainTravel(getMainTravelUpdateDto());
+
+		//then
+		assertEquals(MAIN_TRAVEL_ID, savedMainTravelId);
+		assertEquals(UPDATE_TITLE, mainTravel.getTitle());
+	}
+
+	@Test
+	@DisplayName("MainTravel 삭제 테스트")
+	void deleteMainTravelTest() throws Exception {
+		//given
+		MainTravel mainTravel = getMainTravel();
+		given(mainTravelRepository.findById(MAIN_TRAVEL_ID)).willReturn(Optional.of(mainTravel));
+
+		//when
+		mainTravelService.deleteMainTravel(MAIN_TRAVEL_ID);
+
+		//then
+		verify(mainTravelRepository, times(1)).delete(mainTravel);
+	}
+}

--- a/src/test/java/com/footprint/maintravel/service/dto/MainTravelDtoTest.java
+++ b/src/test/java/com/footprint/maintravel/service/dto/MainTravelDtoTest.java
@@ -1,0 +1,25 @@
+package com.footprint.maintravel.service.dto;
+
+import static com.footprint.maintravel.fixture.MainTravelFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MainTravelDtoTest {
+
+	@Test
+	@DisplayName("MainTravel에서 MainTravelDto 변환 테스트")
+	void fromTest() throws Exception {
+		// given, when
+		MainTravelDto mainTravelDto = MainTravelDto.from(getMainTravel());
+
+		// then
+		assertEquals(getMainTravelDto().title(), mainTravelDto.title());
+		assertEquals(getMainTravelDto().startDate(), mainTravelDto.startDate());
+		assertEquals(getMainTravelDto().endDate(), mainTravelDto.endDate());
+		assertEquals(getMainTravelDto().isVisible(), mainTravelDto.isVisible());
+		assertEquals(getMainTravelDto().isCompleted(), mainTravelDto.isCompleted());
+	}
+
+}

--- a/src/test/java/com/footprint/maintravel/service/dto/MainTravelSaveDtoTest.java
+++ b/src/test/java/com/footprint/maintravel/service/dto/MainTravelSaveDtoTest.java
@@ -1,0 +1,26 @@
+package com.footprint.maintravel.service.dto;
+
+import static com.footprint.maintravel.fixture.MainTravelFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.footprint.maintravel.domain.MainTravel;
+
+class MainTravelSaveDtoTest {
+
+	@Test
+	@DisplayName("SaveDto 에서 Entity 변환 테스트")
+	void toEntityTest() throws Exception{
+	    //given, when
+	    MainTravel mainTravel = getMainTravelSaveDto().toEntity();
+
+	    //then
+		assertEquals(getMainTravel().getTitle(), mainTravel.getTitle());
+		assertEquals(getMainTravel().getStartDate(), mainTravel.getStartDate());
+		assertEquals(getMainTravel().getEndDate(), mainTravel.getEndDate());
+		assertEquals(getMainTravel().getIsVisible(), mainTravel.getIsVisible());
+		assertEquals(getMainTravel().getIsVisible(), mainTravel.getIsVisible());
+	}
+}

--- a/src/test/java/com/footprint/maintravel/service/dto/MainTravelSaveDtoTest.java
+++ b/src/test/java/com/footprint/maintravel/service/dto/MainTravelSaveDtoTest.java
@@ -3,6 +3,8 @@ package com.footprint.maintravel.service.dto;
 import static com.footprint.maintravel.fixture.MainTravelFixture.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
구현한 기능
- MainTravel Repository, Service, Controller 구현
  - MainTravel 단일 조회 기능
  - MainTravel 저장 기능
  - MainTravel 수정 기능
  - MainTravel 삭제 기능
 - 관련 단위 테스트 구현
TODO
- Member 작성자로 연결 하도록 구현
- Detail Travel 구현 후 `detailTravels` 에 추가하도록 구현
- Heart 구현 후 `hearts`에 이를 저장하도록 구현
- Scrap 구현 후 `scraps`에 이를 저장하도록 구현
- 이 후 테스트 수정

close #4 