### PR TITLE
[feature/scrap > develop][#10] Scrap 관련 기능 추가

### DIFF
--- a/src/main/java/com/footprint/maintravel/controller/dto/MainTravelListResponse.java
+++ b/src/main/java/com/footprint/maintravel/controller/dto/MainTravelListResponse.java
@@ -1,0 +1,19 @@
+package com.footprint.maintravel.controller.dto;
+
+import com.footprint.maintravel.service.dto.MainTravelListDto;
+
+public record MainTravelListResponse(
+	Long id,
+	String title,
+	String imagePath,
+	Integer likeNum
+) {
+	public static MainTravelListResponse from(MainTravelListDto mainTravelListDto) {
+		return new MainTravelListResponse(
+			mainTravelListDto.id(),
+			mainTravelListDto.title(),
+			mainTravelListDto.imagePath(),
+			mainTravelListDto.likeNum()
+		);
+	}
+}

--- a/src/main/java/com/footprint/maintravel/service/dto/MainTravelListDto.java
+++ b/src/main/java/com/footprint/maintravel/service/dto/MainTravelListDto.java
@@ -1,0 +1,19 @@
+package com.footprint.maintravel.service.dto;
+
+import com.footprint.maintravel.domain.MainTravel;
+
+public record MainTravelListDto(
+	Long id,
+	String title,
+	String imagePath,
+	Integer likeNum
+) {
+	public static MainTravelListDto from(MainTravel mainTravel) {
+		return new MainTravelListDto(
+			mainTravel.getId(),
+			mainTravel.getTitle(),
+			mainTravel.getImagePath(),
+			mainTravel.getLikeNum()
+		);
+	}
+}

--- a/src/main/java/com/footprint/scrap/controller/ScrapController.java
+++ b/src/main/java/com/footprint/scrap/controller/ScrapController.java
@@ -1,0 +1,50 @@
+package com.footprint.scrap.controller;
+
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.footprint.scrap.controller.dto.ScrapResponse;
+import com.footprint.scrap.service.ScrapService;
+import com.footprint.scrap.service.dto.ScrapDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ScrapController {
+	private final ScrapService scrapService;
+
+	@PostMapping("/members/{memberId}/scraps")
+	public ResponseEntity<Long> saveScrap(@PathVariable Long memberId, @RequestParam Long travelId) {
+		Long scrapId = scrapService.saveScrap(memberId, travelId);
+
+		URI location = ServletUriComponentsBuilder
+			.fromCurrentContextPath().path("/scraps/")
+			.buildAndExpand(scrapId).toUri();
+
+		return ResponseEntity.created(location).body(scrapId);
+	}
+
+	@GetMapping("/members/{memberId}/scraps")
+	public ResponseEntity<List<ScrapResponse>> saveScrap(@PathVariable Long memberId) {
+		List<ScrapDto> scraps = scrapService.getScraps(memberId);
+		return ResponseEntity.ok(scraps.stream().map(ScrapResponse::from).toList());
+	}
+
+	@DeleteMapping("/scraps/{scrapId}")
+	public ResponseEntity<Void> deleteScrap(@PathVariable Long scrapId) {
+		scrapService.deleteScrap(scrapId);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/footprint/scrap/controller/dto/ScrapResponse.java
+++ b/src/main/java/com/footprint/scrap/controller/dto/ScrapResponse.java
@@ -1,0 +1,11 @@
+package com.footprint.scrap.controller.dto;
+
+import com.footprint.maintravel.controller.dto.MainTravelListResponse;
+import com.footprint.scrap.service.dto.ScrapDto;
+
+public record ScrapResponse(Long scrapId, MainTravelListResponse mainTravelListResponse) {
+
+	public static ScrapResponse from(ScrapDto scrapDto) {
+		return new ScrapResponse(scrapDto.scrapId(), MainTravelListResponse.from(scrapDto.mainTravelListDto()));
+	}
+}

--- a/src/main/java/com/footprint/scrap/domain/Scrap.java
+++ b/src/main/java/com/footprint/scrap/domain/Scrap.java
@@ -16,6 +16,7 @@ import com.footprint.maintravel.domain.MainTravel;
 import com.footprint.member.domain.Member;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,4 +38,15 @@ public class Scrap extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "main_travel_id")
 	private MainTravel mainTravel;
+
+	@Builder
+	public Scrap(Member member, MainTravel mainTravel) {
+		this.member = member;
+		setMainTravel(mainTravel);
+	}
+
+	private void setMainTravel(MainTravel mainTravel) {
+		mainTravel.getScraps().add(this);
+		this.mainTravel = mainTravel;
+	}
 }

--- a/src/main/java/com/footprint/scrap/exception/ScrapException.java
+++ b/src/main/java/com/footprint/scrap/exception/ScrapException.java
@@ -1,0 +1,17 @@
+package com.footprint.scrap.exception;
+
+import com.footprint.common.exception.BaseException;
+import com.footprint.common.exception.BaseExceptionType;
+
+public class ScrapException extends BaseException {
+	private final ScrapExceptionType scrapExceptionType;
+
+	public ScrapException(ScrapExceptionType scrapExceptionType) {
+		this.scrapExceptionType = scrapExceptionType;
+	}
+
+	@Override
+	public BaseExceptionType getExceptionType() {
+		return scrapExceptionType;
+	}
+}

--- a/src/main/java/com/footprint/scrap/exception/ScrapExceptionType.java
+++ b/src/main/java/com/footprint/scrap/exception/ScrapExceptionType.java
@@ -1,0 +1,35 @@
+package com.footprint.scrap.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.footprint.common.exception.BaseExceptionType;
+
+public enum ScrapExceptionType implements BaseExceptionType {
+	NOT_FOUND(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND, "해당 스크랩을 찾을 수 없습니다."),
+	CONFLICT(HttpStatus.CONFLICT.value(), HttpStatus.CONFLICT, "해당 스크랩이 중복 되었습니다.");
+
+	private final int errorCode;
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+
+	ScrapExceptionType(int errorCode, HttpStatus httpStatus, String errorMessage) {
+		this.errorCode = errorCode;
+		this.httpStatus = httpStatus;
+		this.errorMessage = errorMessage;
+	}
+
+	@Override
+	public int getErrorCode() {
+		return this.errorCode;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return this.httpStatus;
+	}
+
+	@Override
+	public String getErrorMessage() {
+		return this.errorMessage;
+	}
+}

--- a/src/main/java/com/footprint/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/footprint/scrap/repository/ScrapRepository.java
@@ -11,5 +11,5 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 	boolean existsScrapByMemberIdAndMainTravelId(Long memberId, Long mainTravelId);
 
 	@EntityGraph(attributePaths = {"mainTravel"})
-	List<Scrap> findAllByMemberId(Long memberId);
+	List<Scrap> findAllWithMainTravelByMemberId(Long memberId);
 }

--- a/src/main/java/com/footprint/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/footprint/scrap/repository/ScrapRepository.java
@@ -1,0 +1,15 @@
+package com.footprint.scrap.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.footprint.scrap.domain.Scrap;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+	boolean existsScrapByMemberIdAndMainTravelId(Long memberId, Long mainTravelId);
+
+	@EntityGraph(attributePaths = {"mainTravel"})
+	List<Scrap> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/footprint/scrap/service/ScrapService.java
+++ b/src/main/java/com/footprint/scrap/service/ScrapService.java
@@ -1,0 +1,14 @@
+package com.footprint.scrap.service;
+
+import java.util.List;
+
+import com.footprint.scrap.service.dto.ScrapDto;
+
+public interface ScrapService {
+
+	Long saveScrap(Long memberId, Long travelId);
+
+	void deleteScrap(Long scrapId);
+
+	List<ScrapDto> getScraps(Long memberId);
+}

--- a/src/main/java/com/footprint/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/footprint/scrap/service/ScrapServiceImpl.java
@@ -1,7 +1,6 @@
 package com.footprint.scrap.service;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,7 +56,7 @@ public class ScrapServiceImpl implements ScrapService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<ScrapDto> getScraps(Long memberId) {
-		List<Scrap> scraps = scrapRepository.findAllByMemberId(memberId);
+		List<Scrap> scraps = scrapRepository.findAllWithMainTravelByMemberId(memberId);
 		return scraps.stream().map(ScrapDto::from).toList();
 	}
 }

--- a/src/main/java/com/footprint/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/footprint/scrap/service/ScrapServiceImpl.java
@@ -1,0 +1,63 @@
+package com.footprint.scrap.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.footprint.maintravel.domain.MainTravel;
+import com.footprint.maintravel.exception.MainTravelException;
+import com.footprint.maintravel.exception.MainTravelExceptionType;
+import com.footprint.maintravel.repository.MainTravelRepository;
+import com.footprint.member.domain.Member;
+import com.footprint.member.exception.MemberException;
+import com.footprint.member.exception.MemberExceptionType;
+import com.footprint.member.repository.MemberRepository;
+import com.footprint.scrap.domain.Scrap;
+import com.footprint.scrap.exception.ScrapException;
+import com.footprint.scrap.exception.ScrapExceptionType;
+import com.footprint.scrap.repository.ScrapRepository;
+import com.footprint.scrap.service.dto.ScrapDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ScrapServiceImpl implements ScrapService {
+	private final ScrapRepository scrapRepository;
+	private final MemberRepository memberRepository;
+	private final MainTravelRepository mainTravelRepository;
+
+	@Override
+	public Long saveScrap(Long memberId, Long travelId) {
+		if (existsScrap(memberId, travelId)) {
+			throw new ScrapException(ScrapExceptionType.CONFLICT);
+		}
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND));
+		MainTravel mainTravel = mainTravelRepository.findById(travelId)
+			.orElseThrow(() -> new MainTravelException(MainTravelExceptionType.NOT_FOUND));
+		Scrap scrap = scrapRepository.save(Scrap.builder().member(member).mainTravel(mainTravel).build());
+		return scrap.getId();
+	}
+
+	private boolean existsScrap(Long memberId, Long travelId) {
+		return scrapRepository.existsScrapByMemberIdAndMainTravelId(memberId, travelId);
+	}
+
+	@Override
+	public void deleteScrap(Long scrapId) {
+		Scrap scrap = scrapRepository.findById(scrapId)
+			.orElseThrow(() -> new ScrapException(ScrapExceptionType.NOT_FOUND));
+		scrapRepository.delete(scrap);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<ScrapDto> getScraps(Long memberId) {
+		List<Scrap> scraps = scrapRepository.findAllByMemberId(memberId);
+		return scraps.stream().map(ScrapDto::from).toList();
+	}
+}

--- a/src/main/java/com/footprint/scrap/service/dto/ScrapDto.java
+++ b/src/main/java/com/footprint/scrap/service/dto/ScrapDto.java
@@ -1,0 +1,11 @@
+package com.footprint.scrap.service.dto;
+
+import com.footprint.maintravel.service.dto.MainTravelListDto;
+import com.footprint.scrap.domain.Scrap;
+
+public record ScrapDto(Long scrapId, MainTravelListDto mainTravelListDto) {
+
+	public static ScrapDto from(Scrap scrap) {
+		return new ScrapDto(scrap.getId(), MainTravelListDto.from(scrap.getMainTravel()));
+	}
+}

--- a/src/test/java/com/footprint/maintravel/controller/MainTravelControllerTest.java
+++ b/src/test/java/com/footprint/maintravel/controller/MainTravelControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.footprint.auth.jwt.JwtService;
+import com.footprint.auth.service.AuthService;
 import com.footprint.maintravel.service.MainTravelService;
 import com.footprint.member.repository.MemberRepository;
 

--- a/src/test/java/com/footprint/maintravel/fixture/MainTravelFixture.java
+++ b/src/test/java/com/footprint/maintravel/fixture/MainTravelFixture.java
@@ -14,10 +14,12 @@ import java.util.stream.IntStream;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.footprint.detailtravel.fixture.DetailTravelFixture;
+import com.footprint.maintravel.controller.dto.MainTravelListResponse;
 import com.footprint.maintravel.controller.dto.request.create.CreateMainTravelRequest;
 import com.footprint.maintravel.controller.dto.request.update.UpdateMainTravelRequest;
 import com.footprint.maintravel.controller.dto.response.MainTravelInfoResponse;
 import com.footprint.maintravel.domain.MainTravel;
+import com.footprint.maintravel.service.dto.MainTravelListDto;
 import com.footprint.maintravel.service.dto.info.MainTravelInfoDto;
 import com.footprint.maintravel.service.dto.save.MainTravelSaveDto;
 import com.footprint.maintravel.service.dto.update.MainTravelUpdateDto;
@@ -230,5 +232,13 @@ public class MainTravelFixture {
 			LIKE_NUM,
 			simpleDetailTravelListDto(MAIN_TRAVEL_ID, 3)
 		);
+	}
+
+	public static MainTravelListDto mainTravelListDto() {
+		return new MainTravelListDto(MAIN_TRAVEL_ID, TITLE, IMAGE_PATH, LIKE_NUM);
+	}
+
+	public static MainTravelListResponse mainTravelListResponse() {
+		return new MainTravelListResponse(MAIN_TRAVEL_ID, TITLE, IMAGE_PATH, LIKE_NUM);
 	}
 }

--- a/src/test/java/com/footprint/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/com/footprint/scrap/controller/ScrapControllerTest.java
@@ -42,6 +42,10 @@ class ScrapControllerTest {
 	private MockMvc mockMvc;
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
+	private final String SCRAP_SAVE_URL = "/api/members/{memberId}/scraps";
+	private final String SCRAP_GET_URL = "/api/members/{memberId}/scraps";
+	private final String SCRAP_DELETE_URL = "/api/scraps/{scrapId}";
+
 	@BeforeEach
 	private void setUp(WebApplicationContext webApplicationContext) {
 		mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
@@ -55,7 +59,7 @@ class ScrapControllerTest {
 
 		//when
 		MvcResult mvcResult = mockMvc.perform(
-				post("/api/members/{memberId}/scraps", MEMBER_ID)
+				post(SCRAP_SAVE_URL, MEMBER_ID)
 					.param("travelId", String.valueOf(MAIN_TRAVEL_ID))
 					.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isCreated())
@@ -69,7 +73,7 @@ class ScrapControllerTest {
 	@DisplayName("Scrap 삭제 성공 테스트")
 	void deleteScrapSuccessTest() throws Exception {
 		MvcResult mvcResult = mockMvc.perform(
-				delete("/api/scraps/{scrapId}", SCRAP_ID)
+				delete(SCRAP_DELETE_URL, SCRAP_ID)
 					.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andReturn();
@@ -84,7 +88,7 @@ class ScrapControllerTest {
 
 		//when
 		MvcResult mvcResult = mockMvc.perform(
-				get("/api/members/{memberId}/scraps", MEMBER_ID)
+				get(SCRAP_GET_URL, MEMBER_ID)
 					.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andReturn();

--- a/src/test/java/com/footprint/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/com/footprint/scrap/controller/ScrapControllerTest.java
@@ -1,0 +1,96 @@
+package com.footprint.scrap.controller;
+
+import static com.footprint.maintravel.fixture.MainTravelFixture.*;
+import static com.footprint.scrap.fixture.ScrapFixture.*;
+import static com.footprint.member.fixture.MemberFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.footprint.config.SecurityConfig;
+import com.footprint.scrap.service.ScrapService;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(controllers = ScrapController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+	}
+)
+class ScrapControllerTest {
+	@MockBean
+	private ScrapService scrapService;
+
+	private MockMvc mockMvc;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@BeforeEach
+	private void setUp(WebApplicationContext webApplicationContext) {
+		mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+	}
+
+	@Test
+	@DisplayName("Scrap 성공 테스트")
+	void scrapSuccessTest() throws Exception {
+		//given
+		given(scrapService.saveScrap(MEMBER_ID, MAIN_TRAVEL_ID)).willReturn(SCRAP_ID);
+
+		//when
+		MvcResult mvcResult = mockMvc.perform(
+				post("/api/members/{memberId}/scraps", MEMBER_ID)
+					.param("travelId", String.valueOf(MAIN_TRAVEL_ID))
+					.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isCreated())
+			.andReturn();
+
+		//then
+		assertEquals(String.valueOf(SCRAP_ID), mvcResult.getResponse().getContentAsString());
+	}
+
+	@Test
+	@DisplayName("Scrap 삭제 성공 테스트")
+	void deleteScrapSuccessTest() throws Exception {
+		MvcResult mvcResult = mockMvc.perform(
+				delete("/api/scraps/{scrapId}", SCRAP_ID)
+					.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andReturn();
+	}
+
+	@Test
+	@DisplayName("Scrap 목록 가져오기 성공 테스트")
+	void getScrapsSuccessTest() throws Exception {
+		//given
+		given(scrapService.getScraps(MEMBER_ID)).willReturn(List.of(getScrapDto()));
+		String content = objectMapper.writeValueAsString(List.of(getScrapResponse()));
+
+		//when
+		MvcResult mvcResult = mockMvc.perform(
+				get("/api/members/{memberId}/scraps", MEMBER_ID)
+					.contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		//then
+		assertEquals(content, mvcResult.getResponse().getContentAsString());
+	}
+
+}

--- a/src/test/java/com/footprint/scrap/controller/dto/ScrapResponseTest.java
+++ b/src/test/java/com/footprint/scrap/controller/dto/ScrapResponseTest.java
@@ -1,0 +1,19 @@
+package com.footprint.scrap.controller.dto;
+
+import static com.footprint.scrap.fixture.ScrapFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ScrapResponseTest {
+
+	@Test
+	@DisplayName("ScrapDto 에서 ScrapResponse 변환 테스트")
+	void fromTest() {
+		ScrapResponse scrapResponse = ScrapResponse.from(getScrapDto());
+
+		assertEquals(getScrapResponse().scrapId(), scrapResponse.scrapId());
+		assertEquals(getScrapResponse().mainTravelListResponse(), scrapResponse.mainTravelListResponse());
+	}
+}

--- a/src/test/java/com/footprint/scrap/fixture/ScrapFixture.java
+++ b/src/test/java/com/footprint/scrap/fixture/ScrapFixture.java
@@ -1,0 +1,28 @@
+package com.footprint.scrap.fixture;
+
+import static com.footprint.member.fixture.MemberFixture.*;
+import static com.footprint.maintravel.fixture.MainTravelFixture.*;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.footprint.scrap.controller.dto.ScrapResponse;
+import com.footprint.scrap.domain.Scrap;
+import com.footprint.scrap.service.dto.ScrapDto;
+
+public class ScrapFixture {
+	public static final Long SCRAP_ID = 1L;
+
+	public static Scrap getScrap() {
+		Scrap scrap = Scrap.builder().member(defaultMember()).mainTravel(mainTravelHasId()).build();
+		ReflectionTestUtils.setField(scrap, "id", SCRAP_ID);
+		return scrap;
+	}
+
+	public static ScrapDto getScrapDto() {
+		return new ScrapDto(SCRAP_ID, mainTravelListDto());
+	}
+
+	public static ScrapResponse getScrapResponse() {
+		return new ScrapResponse(SCRAP_ID, mainTravelListResponse());
+	}
+}

--- a/src/test/java/com/footprint/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/footprint/scrap/service/ScrapServiceTest.java
@@ -1,0 +1,102 @@
+package com.footprint.scrap.service;
+
+import static com.footprint.maintravel.fixture.MainTravelFixture.*;
+import static com.footprint.member.fixture.MemberFixture.*;
+import static com.footprint.member.fixture.MemberFixture.MEMBER_ID;
+import static com.footprint.scrap.fixture.ScrapFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.footprint.maintravel.domain.MainTravel;
+import com.footprint.maintravel.exception.MainTravelException;
+import com.footprint.maintravel.repository.MainTravelRepository;
+import com.footprint.member.repository.MemberRepository;
+import com.footprint.scrap.domain.Scrap;
+import com.footprint.scrap.exception.ScrapException;
+import com.footprint.scrap.repository.ScrapRepository;
+import com.footprint.scrap.service.dto.ScrapDto;
+
+@ExtendWith(MockitoExtension.class)
+class ScrapServiceTest {
+	private final ScrapRepository scrapRepository = mock(ScrapRepository.class);
+	private final MemberRepository memberRepository = mock(MemberRepository.class);
+	private final MainTravelRepository mainTravelRepository = mock(MainTravelRepository.class);
+
+	@InjectMocks
+	private ScrapService scrapService = new ScrapServiceImpl(scrapRepository, memberRepository, mainTravelRepository);
+
+	@Test
+	@DisplayName("Scrap에 성공한 경우 테스트")
+	void saveScrapTest() {
+		//given
+		given(scrapRepository.existsScrapByMemberIdAndMainTravelId(MEMBER_ID, MAIN_TRAVEL_ID)).willReturn(false);
+		given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(defaultMember()));
+		given(mainTravelRepository.findById(MAIN_TRAVEL_ID)).willReturn(Optional.of(mainTravelHasId()));
+		given(scrapRepository.save(any())).willReturn(getScrap());
+
+		//when
+		Long scrapId = scrapService.saveScrap(MEMBER_ID, MAIN_TRAVEL_ID);
+
+		//then
+		assertEquals(getScrap().getId(), scrapId);
+	}
+
+	@Test
+	@DisplayName("Scrap에 실패한 경우 테스트 - 해당 글의 스크랩이 존재하는 경우")
+	void saveScrapFailTestConflictScrap() {
+		//given, when
+		given(scrapRepository.existsScrapByMemberIdAndMainTravelId(MEMBER_ID, MAIN_TRAVEL_ID)).willReturn(true);
+
+		//then
+		assertThrows(ScrapException.class, () -> scrapService.saveScrap(MEMBER_ID, MAIN_TRAVEL_ID));
+	}
+
+	@Test
+	@DisplayName("Scrap에 실패한 경우 테스트 - 해당 글이 존재하지 않는 경우")
+	void saveScrapFailTestNotFoundMainTravel() {
+		//given, when
+		given(scrapRepository.existsScrapByMemberIdAndMainTravelId(MEMBER_ID, MAIN_TRAVEL_ID)).willReturn(false);
+		given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(defaultMember()));
+		given(mainTravelRepository.findById(MAIN_TRAVEL_ID)).willThrow(MainTravelException.class);
+
+		//then
+		assertThrows(MainTravelException.class, () -> scrapService.saveScrap(MEMBER_ID, MAIN_TRAVEL_ID));
+	}
+
+	@Test
+	@DisplayName("Scrap 삭제 테스트")
+	void deleteScrapTest() {
+		//given
+		Scrap scrap = getScrap();
+		given(scrapRepository.findById(SCRAP_ID)).willReturn(Optional.of(scrap));
+
+		//when
+		scrapService.deleteScrap(SCRAP_ID);
+
+		//then
+		verify(scrapRepository, times(1)).delete(scrap);
+	}
+
+	@Test
+	@DisplayName("해당 유저의 Scrap 목록 가져오기 테스트")
+	void getScrapsTest() {
+		//given
+		given(scrapRepository.findAllByMemberId(MEMBER_ID)).willReturn(List.of(getScrap()));
+
+		//when
+		List<ScrapDto> scraps = scrapService.getScraps(MEMBER_ID);
+
+		//then
+		assertEquals(1, scraps.size());
+	}
+}

--- a/src/test/java/com/footprint/scrap/service/ScrapServiceTest.java
+++ b/src/test/java/com/footprint/scrap/service/ScrapServiceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.footprint.maintravel.domain.MainTravel;
 import com.footprint.maintravel.exception.MainTravelException;
 import com.footprint.maintravel.repository.MainTravelRepository;
 import com.footprint.member.repository.MemberRepository;
@@ -91,7 +90,7 @@ class ScrapServiceTest {
 	@DisplayName("해당 유저의 Scrap 목록 가져오기 테스트")
 	void getScrapsTest() {
 		//given
-		given(scrapRepository.findAllByMemberId(MEMBER_ID)).willReturn(List.of(getScrap()));
+		given(scrapRepository.findAllWithMainTravelByMemberId(MEMBER_ID)).willReturn(List.of(getScrap()));
 
 		//when
 		List<ScrapDto> scraps = scrapService.getScraps(MEMBER_ID);

--- a/src/test/java/com/footprint/scrap/service/dto/ScrapDtoTest.java
+++ b/src/test/java/com/footprint/scrap/service/dto/ScrapDtoTest.java
@@ -1,0 +1,22 @@
+package com.footprint.scrap.service.dto;
+
+import static com.footprint.scrap.fixture.ScrapFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ScrapDtoTest {
+	@Test
+	@DisplayName("MainTravel에서 MainTravelDto 변환 테스트")
+	void fromTest() {
+		// given, when
+		ScrapDto scrapDto = ScrapDto.from(getScrap());
+
+		// then
+		assertEquals(getScrapDto().scrapId(), scrapDto.scrapId());
+		assertEquals(getScrapDto().mainTravelListDto(), scrapDto.mainTravelListDto());
+		assertEquals(getScrapDto().mainTravelListDto().title(), scrapDto.mainTravelListDto().title());
+		assertEquals(getScrapDto().mainTravelListDto().likeNum(), scrapDto.mainTravelListDto().likeNum());
+	}
+}


### PR DESCRIPTION
구현한 기능
- Scrap Repository, Service, Controller 구현
  - Scrap 기능
  - Scrap 삭제기능
  - Scrap 목록 확인 기능
- 관련 단위 테스트 구현
TODO
- Scrap 목록을 확인할 때, 아래 그림처럼 보이게 MainTravelListResponse생성했음
  - comment 구현 후, comment 수 확인할 수 있도록 추가 구현
<img width="281" alt="image" src="https://user-images.githubusercontent.com/55012742/176670373-893d77e9-afc5-42e2-bd54-25e59bb5259a.png">

close #10 